### PR TITLE
Exception handling

### DIFF
--- a/Alluvial.Tests/PipelineTests.cs
+++ b/Alluvial.Tests/PipelineTests.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Alluvial.Tests.BankDomain;
 using FluentAssertions;
+using Its.Log.Instrumentation;
 using NUnit.Framework;
 
 namespace Alluvial.Tests
@@ -100,6 +102,54 @@ namespace Alluvial.Tests
             aggregator.Aggregate(null, null);
 
             time.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public async Task Pipelines_affect_projections_in_reverse_order_relative_to_the_Pipeline_calls_when_next_is_called_after_modifying_the_projection()
+        {
+            var aggregator = Aggregator.Create<List<int>, string>((projection, events) => projection.Add(1))
+                                       .Pipeline((projection, batch, next) =>
+                                       {
+                                           projection.Add(2);
+                                           next(projection, batch);
+                                           return projection;
+                                       })
+                                       .Pipeline((projection, batch, next) =>
+                                       {
+                                           projection.Add(3);
+                                           next(projection, batch);
+                                           return projection;
+                                       });
+
+            var result = aggregator.Aggregate(new List<int>(), null);
+
+            Console.WriteLine(result.ToLogString());
+
+            result.Should().BeInDescendingOrder();
+        }
+
+        [Test]
+        public async Task Pipelines_affect_projections_in_the_same_order_as_the_Pipeline_calls_when_next_is_called_before_modifying_the_projection()
+        {
+            var aggregator = Aggregator.Create<List<int>, string>((projection, events) => projection.Add(1))
+                                       .Pipeline((projection, batch, next) =>
+                                       {
+                                           next(projection, batch);
+                                           projection.Add(2);
+                                           return projection;
+                                       })
+                                       .Pipeline((projection, batch, next) =>
+                                       {
+                                           next(projection, batch);
+                                           projection.Add(3);
+                                           return projection;
+                                       });
+
+            var result = aggregator.Aggregate(new List<int>(), null);
+
+            Console.WriteLine(result.ToLogString());
+
+            result.Should().BeInAscendingOrder();
         }
     }
 }

--- a/Alluvial/Alluvial.csproj
+++ b/Alluvial/Alluvial.csproj
@@ -77,6 +77,7 @@
     <Compile Include="AlphabeticalCursor.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Alluvial.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Alluvial/Alluvial.nuspec
+++ b/Alluvial/Alluvial.nuspec
@@ -3,7 +3,6 @@
   <metadata>
     <id>Alluvial</id>
     <title>Alluvial</title>
-    <version>0.1.0-alpha</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/Alluvial</projectUrl>

--- a/Alluvial/Alluvial.nuspec
+++ b/Alluvial/Alluvial.nuspec
@@ -3,6 +3,7 @@
   <metadata>
     <id>Alluvial</id>
     <title>Alluvial</title>
+    <version>0.1.1-alpha</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/Alluvial</projectUrl>

--- a/Alluvial/Properties/AssemblyInfo.cs
+++ b/Alluvial/Properties/AssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("ae1d48e9-ffcd-4e5e-b052-70e5446dfa23")]
 
 [assembly: AssemblyVersion("0.1.0")]
-[assembly: AssemblyFileVersion("0.1.0-alpha")]
+[assembly: AssemblyFileVersion("0.1.1-alpha")]


### PR DESCRIPTION
Small change to catchup here, and some additional pipeline examples and methods, including Catch which can be used to prevent exceptions from halting a catchup.