### PR TITLE
Command scheduling improvements

### DIFF
--- a/Alluvial.ForItsCqrs.Tests/Alluvial.Streams.ItsDomainSql.Tests.csproj
+++ b/Alluvial.ForItsCqrs.Tests/Alluvial.Streams.ItsDomainSql.Tests.csproj
@@ -63,15 +63,15 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Its.Domain, Version=0.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Its.Domain.0.13.11-beta\lib\net451\Microsoft.Its.Domain.dll</HintPath>
+      <HintPath>..\packages\Its.Domain.0.13.12-beta\lib\net451\Microsoft.Its.Domain.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Its.Domain.Sql, Version=0.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Its.Domain.Sql.0.13.11-beta\lib\net451\Microsoft.Its.Domain.Sql.dll</HintPath>
+      <HintPath>..\packages\Its.Domain.Sql.0.13.12-beta\lib\net451\Microsoft.Its.Domain.Sql.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Its.Domain.Testing, Version=0.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Its.Domain.Testing.0.13.11-beta\lib\net451\Microsoft.Its.Domain.Testing.dll</HintPath>
+      <HintPath>..\packages\Its.Domain.Testing.0.13.12-beta\lib\net451\Microsoft.Its.Domain.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Alluvial.ForItsCqrs.Tests/CommandSchedulerTests.cs
+++ b/Alluvial.ForItsCqrs.Tests/CommandSchedulerTests.cs
@@ -1,14 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.Data.Entity;
+using FluentAssertions;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
-using FluentAssertions;
-using Its.Log.Instrumentation;
 using Microsoft.Its.Domain;
 using Microsoft.Its.Domain.Sql;
 using Microsoft.Its.Domain.Sql.CommandScheduler;
 using NUnit.Framework;
+using Clock = Microsoft.Its.Domain.Clock;
+using SchedulerClock = Microsoft.Its.Domain.Sql.CommandScheduler.Clock;
 
 namespace Alluvial.Streams.ItsDomainSql.Tests
 {
@@ -37,7 +39,6 @@ namespace Alluvial.Streams.ItsDomainSql.Tests
                 .TraceScheduledCommands();
 
             disposables.Add(ConfigurationContext.Establish(configuration));
-            disposables = new CompositeDisposable();
         }
 
         [TearDown]
@@ -47,23 +48,24 @@ namespace Alluvial.Streams.ItsDomainSql.Tests
         }
 
         [Test]
-        public async Task The_command_scheduler_queue_can_be_processed_as_a_stream()
+        public async Task Commands_on_a_single_clock_can_be_processed_as_a_stream()
         {
-            ScheduleSomeCommands(50);
+            // arrange
+            await ScheduleSomeCommands(50);
 
-            var catchup = EventStream.ScheduledCommandStream(clockName)
-                                     .DistributeAmong(Partition.AllGuids()
-                                                               .Among(16)
-                                                               .ToArray());
+            var catchup = CommandScheduler.CommandsDueOnClock(clockName)
+                                          .DistributeAmong(Partition.AllGuids()
+                                                                    .Among(16)
+                                                                    .ToArray());
 
             var store = new InMemoryProjectionStore<CommandsApplied>();
 
-            catchup.Subscribe(EventStream.DeliverScheduledCommands().Trace(), store);
+            catchup.Subscribe(CommandScheduler.DeliverScheduledCommands().Trace(), store);
 
+            // act
             await catchup.RunSingleBatch();
 
-            Console.WriteLine(store.ToLogString());
-
+            // assert
             store.Sum(c => c.Value.Count).Should().Be(50);
 
             using (var db = new CommandSchedulerDbContext())
@@ -76,20 +78,74 @@ namespace Alluvial.Streams.ItsDomainSql.Tests
             }
         }
 
-        private static void ScheduleSomeCommands(
-            int howMany = 20,
-            DateTimeOffset? dueTime = null)
+        [Test]
+        public async Task All_clocks_can_be_advanced_in_parallel_using_a_distributor()
         {
-            Enumerable.Range(1, howMany)
-                      .Select(_ => Guid.NewGuid())
-                      .ToList()
-                      .ForEach(id =>
-                      {
-                          var scheduler = Configuration.Current.CommandScheduler<AggregateA>();
-                          scheduler.Schedule(id,
-                                             new CreateAggregateA(),
-                                             dueTime).Wait();
-                      });
+            // arrange
+            var commandsScheduled = await ScheduleSomeCommands(
+                50,
+                Clock.Now().Subtract(1.Hours()),
+                clockName: () => Guid.NewGuid().ToString());
+
+            var partitions = new[]
+            {
+                Partition.ByRange("", "3"),
+                Partition.ByRange("3", "7"),
+                Partition.ByRange("7", "b"),
+                Partition.ByRange("b", "f"),
+                Partition.ByRange("f", "j"),
+                Partition.ByRange("j", "n"),
+                Partition.ByRange("n", "r"),
+                Partition.ByRange("r", "v"),
+                Partition.ByRange("v", "zz")
+            };
+
+            var clockStream = CommandScheduler.ClocksWithCommandsDue().Trace();
+            var catchup = clockStream.DistributeAmong(partitions);
+            var store = new InMemoryProjectionStore<CommandsApplied>();
+            var aggregator = CommandScheduler.AdvanceClocks();
+            catchup.Subscribe(aggregator, store);
+
+            // act
+            await catchup.RunUntilCaughtUp();
+
+            // assert
+            store.Count().Should().Be(partitions.Length);
+
+            var commandsDelivered = store
+                .SelectMany(_ => _.Value)
+                .ToArray();
+
+            commandsDelivered.Length
+                             .Should()
+                             .Be(commandsScheduled.Count());
+        }
+
+        private static async Task<IEnumerable<IScheduledCommand<AggregateA>>> ScheduleSomeCommands(
+            int howMany = 20,
+            DateTimeOffset? dueTime = null,
+            Func<string> clockName = null)
+        {
+            if (clockName != null)
+            {
+                Configuration.Current.UseDependency<GetClockName>(c => _ => clockName());
+            }
+
+            var commandsScheduled = new List<IScheduledCommand<AggregateA>>();
+
+            foreach (var id in Enumerable.Range(1, howMany).Select(_ => Guid.NewGuid()))
+            {
+                var scheduler = Configuration.Current.CommandScheduler<AggregateA>();
+                var command = await scheduler.Schedule(id,
+                                                       new CreateAggregateA
+                                                       {
+                                                           AggregateId = id
+                                                       },
+                                                       dueTime);
+                commandsScheduled.Add(command);
+            }
+
+            return commandsScheduled;
         }
     }
 }

--- a/Alluvial.ForItsCqrs.Tests/DatabaseSetup.cs
+++ b/Alluvial.ForItsCqrs.Tests/DatabaseSetup.cs
@@ -1,4 +1,3 @@
-using System.Data.Entity;
 using Microsoft.Its.Domain.Sql;
 using Microsoft.Its.Domain.Sql.CommandScheduler;
 
@@ -13,7 +12,10 @@ namespace Alluvial.Streams.ItsDomainSql.Tests
         {
             SetConnectionStrings();
 
-            Database.SetInitializer(new CreateAndMigrate<CommandSchedulerDbContext>());
+            using (var db = new CommandSchedulerDbContext())
+            {
+                new CommandSchedulerDatabaseInitializer().InitializeDatabase(db);
+            }
 
             lock (lockObj)
             {

--- a/Alluvial.ForItsCqrs.Tests/DatabaseSetup.cs
+++ b/Alluvial.ForItsCqrs.Tests/DatabaseSetup.cs
@@ -1,3 +1,4 @@
+using System.Data.Entity;
 using Microsoft.Its.Domain.Sql;
 using Microsoft.Its.Domain.Sql.CommandScheduler;
 
@@ -11,6 +12,8 @@ namespace Alluvial.Streams.ItsDomainSql.Tests
         public static void Run()
         {
             SetConnectionStrings();
+
+            Database.SetInitializer(new CreateAndMigrate<CommandSchedulerDbContext>());
 
             lock (lockObj)
             {

--- a/Alluvial.ForItsCqrs.Tests/packages.config
+++ b/Alluvial.ForItsCqrs.Tests/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="FluentAssertions" version="4.2.1" targetFramework="net451" />
-  <package id="Its.Domain" version="0.13.11-beta" targetFramework="net451" />
-  <package id="Its.Domain.Sql" version="0.13.11-beta" targetFramework="net451" />
-  <package id="Its.Domain.Testing" version="0.13.11-beta" targetFramework="net451" />
+  <package id="Its.Domain" version="0.13.12-beta" targetFramework="net451" />
+  <package id="Its.Domain.Sql" version="0.13.12-beta" targetFramework="net451" />
+  <package id="Its.Domain.Testing" version="0.13.12-beta" targetFramework="net451" />
   <package id="Its.Log" version="2.9.11" targetFramework="net451" />
   <package id="Its.Validation" version="1.4.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />

--- a/Alluvial.ForItsCqrs/Alluvial.Streams.ItsDomainSql.csproj
+++ b/Alluvial.ForItsCqrs/Alluvial.Streams.ItsDomainSql.csproj
@@ -45,11 +45,11 @@
       <HintPath>..\packages\Its.Validation.1.4.3\lib\net45\Its.Validation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Its.Domain, Version=0.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Its.Domain.0.13.11-beta\lib\net451\Microsoft.Its.Domain.dll</HintPath>
+      <HintPath>..\packages\Its.Domain.0.13.12-beta\lib\net451\Microsoft.Its.Domain.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Its.Domain.Sql, Version=0.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Its.Domain.Sql.0.13.11-beta\lib\net451\Microsoft.Its.Domain.Sql.dll</HintPath>
+      <HintPath>..\packages\Its.Domain.Sql.0.13.12-beta\lib\net451\Microsoft.Its.Domain.Sql.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -87,6 +87,7 @@
     </Compile>
     <Compile Include="AlluvialDistributorLeaseInitializer.cs" />
     <Compile Include="CommandsApplied.cs" />
+    <Compile Include="CommandScheduler.cs" />
     <Compile Include="EventStream.cs" />
     <Compile Include="EventStreamChange.cs" />
     <Compile Include="%28Pocket%29\MaybeExtensions.cs" />

--- a/Alluvial.ForItsCqrs/CommandScheduler.cs
+++ b/Alluvial.ForItsCqrs/CommandScheduler.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Data.Entity;
+using System.Linq;
+using Microsoft.Its.Domain;
+using Microsoft.Its.Domain.Sql;
+using Microsoft.Its.Domain.Sql.CommandScheduler;
+using SchedulerClock = Microsoft.Its.Domain.Sql.CommandScheduler.Clock;
+using DomainClock = Microsoft.Its.Domain.Clock;
+
+namespace Alluvial.Streams.ItsDomainSql
+{
+    public static class CommandScheduler
+    {
+        /// <summary>
+        /// Creates a stream aggregator that advances scheduler clocks to the current domain time, triggering any commands that are scheduled on the clock and due.
+        /// </summary>
+        public static IStreamAggregator<CommandsApplied, SchedulerClock> AdvanceClocks() => Aggregator.Create<CommandsApplied, SchedulerClock>(async (applied, batch) =>
+        {
+            var trigger = Configuration.Current.SchedulerClockTrigger();
+
+            foreach (var clock in batch)
+            {
+                var result = await trigger.AdvanceClock(
+                    clock.Name, 
+                    DomainClock.Now());
+
+                foreach (var x in result.SuccessfulCommands)
+                {
+                    applied.Value.Add(x);
+                }
+
+                foreach (var x in result.FailedCommands)
+                {
+                    applied.Value.Add(x);
+                }
+            }
+
+            return applied;
+        });
+
+        /// <summary>
+        /// Gets a partitioned stream containing clocks that have commands due.
+        /// </summary>
+        /// <param name="asOf">The time as of which commands are evaluated to determine whether they are due.</param>
+        public static IPartitionedStream<SchedulerClock, DateTimeOffset, string> ClocksWithCommandsDue(DateTimeOffset? asOf = null) =>
+            Stream.PartitionedByRange<SchedulerClock, DateTimeOffset, string>(
+                query: async (query, partition) =>
+                {
+                    using (var db = new CommandSchedulerDbContext())
+                    {
+                        var q = from clock in db.Clocks.WithinPartition(c => c.Name, partition)
+                                join cmd in db.ScheduledCommands.Due(asOf)
+                                    on clock equals cmd.Clock
+                                orderby clock.UtcNow
+                                select clock;
+
+                        return await q.Take(query.BatchSize ?? 1)
+                                      .ToArrayAsync();
+                    }
+                },
+                advanceCursor: (q, b) => q.Cursor.AdvanceTo(DomainClock.Now()));
+
+        /// <summary>
+        /// Creates a partitioned stream of scheduled commands due on a specified scheduler clock.
+        /// </summary>
+        /// <param name="clockName">Name of the scheduler clock.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">Clock name cannot be null, empty, or consist entirely of whitespace.</exception>
+        public static IPartitionedStream<ScheduledCommand, DateTimeOffset, Guid> CommandsDueOnClock(string clockName)
+        {
+            if (String.IsNullOrWhiteSpace(clockName))
+            {
+                throw new ArgumentException("Clock name cannot be null, empty, or consist entirely of whitespace.", nameof(clockName));
+            }
+
+            return Stream.PartitionedByRange<ScheduledCommand, DateTimeOffset, Guid>(
+                async (q, partition) =>
+                {
+                    using (var db = new CommandSchedulerDbContext())
+                    {
+                        var batchCount = q.BatchSize ?? 5;
+                        var query = db.ScheduledCommands
+                                      .Due()
+                                      .Where(c => c.Clock.Name == clockName)
+                                      .WithinPartition(e => e.AggregateId, partition)
+                                      .Take(() => batchCount);
+                        var scheduledCommands = await query.ToArrayAsync();
+                        return scheduledCommands;
+                    }
+                },
+                advanceCursor: (q, b) => q.Cursor.AdvanceTo(DomainClock.Now()));
+        }
+
+        /// <summary>
+        /// Creates a stream aggregator that delivers scheduled commands.
+        /// </summary>
+        /// <returns></returns>
+        public static IStreamAggregator<CommandsApplied, ScheduledCommand> DeliverScheduledCommands() =>
+            Aggregator.Create<CommandsApplied, ScheduledCommand>(
+                async (applied, batch) =>
+                {
+                    var configuration = Configuration.Current;
+
+                    using (var commandSchedulerDb = new CommandSchedulerDbContext())
+                    {
+                        foreach (var cmd in batch)
+                        {
+                            await configuration.DeserializeAndDeliver(
+                                cmd,
+                                commandSchedulerDb);
+
+                            applied.Value.Add(cmd.Result);
+                        }
+                        await commandSchedulerDb.SaveChangesAsync();
+                    }
+
+                    return applied;
+                });
+    }
+}

--- a/Alluvial.ForItsCqrs/CommandsApplied.cs
+++ b/Alluvial.ForItsCqrs/CommandsApplied.cs
@@ -1,9 +1,10 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Its.Domain;
 
 namespace Alluvial.Streams.ItsDomainSql
 {
-    public class CommandsApplied : Projection<IList<ScheduledCommandResult>, long>
+    public class CommandsApplied : Projection<IList<ScheduledCommandResult>, DateTimeOffset>
     {
         public CommandsApplied()
         {

--- a/Alluvial.ForItsCqrs/EventStream.cs
+++ b/Alluvial.ForItsCqrs/EventStream.cs
@@ -5,30 +5,17 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Its.Domain;
 using Microsoft.Its.Domain.Sql;
-using Microsoft.Its.Domain.Sql.CommandScheduler;
 using Pocket;
 
 namespace Alluvial.Streams.ItsDomainSql
 {
     public static class EventStream
     {
-        public static IStreamAggregator<CommandsApplied, ScheduledCommand> DeliverScheduledCommands() =>
-            Aggregator.Create<CommandsApplied, ScheduledCommand>(
-                async (projection, batch) =>
-                {
-                    using (var commandSchedulerDb = new CommandSchedulerDbContext())
-                    {
-                        foreach (var cmd in batch)
-                        {
-                            await Configuration.Current.DeserializeAndDeliver(cmd, commandSchedulerDb);
-                            projection.Value.Add(cmd.Result);
-                        }
-                        await commandSchedulerDb.SaveChangesAsync();
-                    }
-
-                    return projection;
-                });
-
+        /// <summary>
+        /// Returns a stream of streams, each of which contains all of the events for a single aggregate.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="storableEvents">A delegate returning a query of events to include in the stream.</param>
         public static IStream<IStream<IEvent, long>, long> PerAggregate(
             string streamId,
             Func<IQueryable<StorableEvent>> storableEvents) =>
@@ -45,6 +32,11 @@ namespace Alluvial.Streams.ItsDomainSql
                                             toCursor),
                             (query, batch) => AdvanceCursor(batch, query, toCursor)).CompletedTask());
 
+        /// <summary>
+        /// Returns a partitioned stream of streams, each of which contains all of the events for a single aggregate.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="storableEvents">A delegate returning a query of events to include in the stream.</param>
         public static IPartitionedStream<IStream<IEvent, long>, long, Guid> PerAggregatePartitioned(
             string streamId,
             Func<IQueryable<StorableEvent>> storableEvents) =>
@@ -60,43 +52,6 @@ namespace Alluvial.Streams.ItsDomainSql
                                                   toCursor),
                                   (query, batch) => AdvanceCursor(batch, query, toCursor))
                                     .CompletedTask());
-
-        public static IPartitionedStream<ScheduledCommand, long, Guid> ScheduledCommandStream(string clockName = "default") =>
-            Stream.PartitionedByRange<ScheduledCommand, long, Guid>(
-                async (q, partition) =>
-                {
-                    using (var db = new CommandSchedulerDbContext())
-                    {
-                        var batchCount = q.BatchSize ?? 5;
-                        var query = db.ScheduledCommands
-                                      .Due()
-                                      .Where(c => c.Clock.Name == clockName)
-                                      .WithinPartition(e => e.AggregateId, partition)
-                                      .Take(() => batchCount);
-                        var scheduledCommands = await query.ToArrayAsync();
-                        return scheduledCommands;
-                    }
-                },
-                advanceCursor: (q, b) =>
-                {
-                    q.Cursor.AdvanceTo(DateTimeOffset.UtcNow.Ticks);
-
-                    // advance the cursor to the latest due time
-                    //                    var latestDuetime = b
-                    //                        .Select(c => c.DueTime)
-                    //                        .Where(d => d != null)
-                    //                        .Select(d => d.Value)
-                    //                        .OrderBy(d => d)
-                    //                        .LastOrDefault();
-                    //                    if (latestDuetime != default(DateTimeOffset))
-                    //                    {
-                    //                        q.Cursor.AdvanceTo(latestDuetime);
-                    //                    }
-                    //                    else
-                    //                    {
-                    //                        q.Cursor.AdvanceTo(DateTimeOffset.UtcNow);
-                    //                    }
-                });
 
         private static IStream<EventStreamChange, long> AllChanges(
             string streamId,
@@ -148,16 +103,16 @@ namespace Alluvial.Streams.ItsDomainSql
             }
 
             var fetchedFromEventStore = await query
-                .OrderBy(e => e.Id)
-                .Select(e => new
-                {
-                    e.AggregateId,
-                    e.StreamName,
-                    e.Id
-                })
-                .Take(streamQuery.BatchSize ?? 10)
-                .GroupBy(e => e.AggregateId)
-                .ToArrayAsync();
+                                                  .OrderBy(e => e.Id)
+                                                  .Select(e => new
+                                                  {
+                                                      e.AggregateId,
+                                                      e.StreamName,
+                                                      e.Id
+                                                  })
+                                                  .Take(streamQuery.BatchSize ?? 10)
+                                                  .GroupBy(e => e.AggregateId)
+                                                  .ToArrayAsync();
 
             var eventStreamChanges = fetchedFromEventStore
                 .Select(e => new EventStreamChange(e.Key)

--- a/Alluvial.ForItsCqrs/packages.config
+++ b/Alluvial.ForItsCqrs/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
-  <package id="Its.Domain" version="0.13.11-beta" targetFramework="net451" />
-  <package id="Its.Domain.Sql" version="0.13.11-beta" targetFramework="net451" />
+  <package id="Its.Domain" version="0.13.12-beta" targetFramework="net451" />
+  <package id="Its.Domain.Sql" version="0.13.12-beta" targetFramework="net451" />
   <package id="Its.Validation" version="1.4.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net451" />


### PR DESCRIPTION
I reorganized command scheduling-related code in Alluvial.Streams.ItsDomainSql (which could probably use a better name) and added support for advancing scheduler clocks using a distributor and a partitioned stream of clocks that have commands due.