### PR TITLE
Distributed catchup is a distributor

### DIFF
--- a/Alluvial.Distributors.Sql/Distributor.cs
+++ b/Alluvial.Distributors.Sql/Distributor.cs
@@ -10,40 +10,49 @@ namespace Alluvial.Distributors.Sql
     public static class Distributor
     {
         /// <summary>
-        /// Distributes the work of querying specified partitions using a SQL-backed distributor.
+        /// Creates a SQL-brokered distributor.
         /// </summary>
-        /// <typeparam name="TData">The type of the data in the stream.</typeparam>
         /// <typeparam name="TPartition">The type of the partition.</typeparam>
-        /// <param name="catchup">The catchup.</param>
-        /// <param name="partitions">The partitions to distribute.</param>
-        /// <param name="database">The database backing the SQL brokered distributor.</param>
-        /// <param name="pool">The pool in which the leasable resources are registered.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException">
+        /// <param name="partitions">The partitions to be leased out.</param>
+        /// <param name="database">The database where the leases are stored.</param>
+        /// <param name="pool">The pool.</param>
+        ///   /// <param name="waitInterval">The interval to wait after a lease is released before which leased resource should not become available again. If not specified, the default is .5 seconds.</param>
+        /// <param name="defaultLeaseDuration">The default duration of a lease. If not specified, the default duration is five minutes.</param>
+        /// <param name="maxDegreesOfParallelism">The maximum number of leases to be distributed at one time by this distributor instance.</param>
+        /// <exception cref="System.ArgumentNullException">
         /// </exception>
-        public static IDistributedStreamCatchup<TData, TPartition> DistributeSqlBrokeredLeasesAmong<TData, TPartition>(
-            this IDistributedStreamCatchup<TData, TPartition> catchup,
-            IEnumerable<IStreamQueryPartition<TPartition>> partitions,
+        public static IDistributor<IStreamQueryPartition<TPartition>> CreateSqlBrokeredDistributor<TPartition>(
+            this IEnumerable<IStreamQueryPartition<TPartition>> partitions,
             SqlBrokeredDistributorDatabase database,
-            string pool)
+            string pool,
+            int maxDegreesOfParallelism = 5,
+            TimeSpan? waitInterval = null,
+            TimeSpan? defaultLeaseDuration = null)
         {
-            if (catchup == null)
-            {
-                throw new ArgumentNullException(nameof(catchup));
-            }
             if (partitions == null)
             {
                 throw new ArgumentNullException(nameof(partitions));
             }
+            if (database == null)
+            {
+                throw new ArgumentNullException(nameof(database));
+            }
+            if (pool == null)
+            {
+                throw new ArgumentNullException(nameof(pool));
+            }
 
-            var partitionsArray = partitions as IStreamQueryPartition<TPartition>[] ?? partitions.ToArray();
+            var leasables = partitions.CreateLeasables();
 
             var distributor = new SqlBrokeredDistributor<IStreamQueryPartition<TPartition>>(
-                partitionsArray.CreateLeasables(),
+                leasables,
                 database,
-                pool);
+                pool,
+                maxDegreesOfParallelism,
+                waitInterval,
+                defaultLeaseDuration);
 
-            return catchup.DistributeAmong(partitionsArray, distributor);
+            return distributor;
         }
     }
 }

--- a/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
+++ b/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
@@ -17,7 +17,8 @@ namespace Alluvial.Distributors.Sql
         private readonly SqlBrokeredDistributorDatabase database;
         private readonly string pool;
         private readonly TimeSpan defaultLeaseDuration;
-
+        private bool isDatabaseInitialized = false;
+         
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlBrokeredDistributor{T}"/> class.
         /// </summary>
@@ -176,6 +177,11 @@ namespace Alluvial.Distributors.Sql
 
         private async Task EnsureDatabaseIsInitialized()
         {
+            if (isDatabaseInitialized)
+            {
+                return;
+            }
+
             await database.InitializeSchema();
             await database.RegisterLeasableResources(
                 Leasables,

--- a/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
+++ b/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
@@ -17,16 +17,16 @@ namespace Alluvial.Distributors.Sql
         private readonly SqlBrokeredDistributorDatabase database;
         private readonly string pool;
         private readonly TimeSpan defaultLeaseDuration;
-        private bool isDatabaseInitialized = false;
-         
+        private readonly bool isDatabaseInitialized = false;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlBrokeredDistributor{T}"/> class.
         /// </summary>
         /// <param name="leasables">The leasable resources.</param>
-        /// <param name="database">The database.</param>
+        /// <param name="database">The database where the leases are stored.</param>
         /// <param name="pool">The name of the pool of leasable resources from which leases are acquired.</param>
-        /// <param name="maxDegreesOfParallelism">The maximum degrees of parallelism per machine.</param>
-        /// <param name="waitInterval">The interval to wait before a released lease can be reacquired.</param>
+        /// <param name="maxDegreesOfParallelism">The maximum number of leases to be distributed at one time by this distributor instance.</param>
+        /// <param name="waitInterval">The interval to wait after a lease is released before which leased resource should not become available again. If not specified, the default is .5 seconds.</param>
         /// <param name="defaultLeaseDuration">The default duration of a lease. If not specified, the default duration is five minutes.</param>
         /// <exception cref="System.ArgumentNullException">
         /// database

--- a/Alluvial.For.ItsDomainSql.Tests/ProjectionTests.cs
+++ b/Alluvial.For.ItsDomainSql.Tests/ProjectionTests.cs
@@ -84,8 +84,11 @@ namespace Alluvial.For.ItsDomainSql.Tests
                 projection.Value.AddRange(eventType14s);
             }).Trace();
 
-            var catchup = streams.CreateDistributedCatchup()
-                                 .DistributeInMemoryAmong(Partition.AllGuids().Among(10));
+            var distributor = Partition.AllGuids()
+                                       .Among(10)
+                                       .CreateInMemoryDistributor();
+
+            var catchup = streams.CreateDistributedCatchup(distributor);
 
             var store = new InMemoryProjectionStore<MatchingEvents>();
             catchup.Subscribe(aggregator, store.Trace());

--- a/Alluvial.Tests/MultiStreamCatchupTests.cs
+++ b/Alluvial.Tests/MultiStreamCatchupTests.cs
@@ -555,16 +555,15 @@ namespace Alluvial.Tests
                                    .Select(Partition.ByValue)
                                    .ToArray();
 
-            var distributor = partitions
-                .CreateInMemoryDistributor(
-                    waitInterval: TimeSpan.FromSeconds(.5),
-                    maxDegreesOfParallelism: 30,
-                    defaultLeaseDuration: 5.Seconds())
-                .Trace();
+            var distributor = partitions.CreateInMemoryDistributor(
+                waitInterval: TimeSpan.FromSeconds(.5),
+                maxDegreesOfParallelism: 30,
+                defaultLeaseDuration: 5.Seconds())
+                                        .Trace();
 
-            var catchup = streams.CreateDistributedCatchup()
-                                 .Backoff(5.Seconds())
-                                 .DistributeAmong(partitions, distributor);
+            var catchup = streams.CreateDistributedCatchup(distributor)
+                                 .Backoff(5.Seconds());
+
 
             catchup.Subscribe(async (p, b) =>
             {

--- a/Alluvial.Tests/MultiStreamCatchupTests.cs
+++ b/Alluvial.Tests/MultiStreamCatchupTests.cs
@@ -564,7 +564,6 @@ namespace Alluvial.Tests
             var catchup = streams.CreateDistributedCatchup(distributor)
                                  .Backoff(5.Seconds());
 
-
             catchup.Subscribe(async (p, b) =>
             {
                 p.Value = p.Value ?? new List<string>();

--- a/Alluvial.Tests/ProjectionTests.cs
+++ b/Alluvial.Tests/ProjectionTests.cs
@@ -96,8 +96,11 @@ namespace Alluvial.Tests
                         }
                     });
 
-            var catchup = partitionedStream.CreateDistributedCatchup()
-                                           .DistributeInMemoryAmong(Partition.ByRange(1, 1000).Among(1));
+            var distributor = Partition.ByRange(1, 1000)
+                                       .Among(1)
+                                       .CreateInMemoryDistributor();
+
+            var catchup = partitionedStream.CreateDistributedCatchup(distributor);
 
             Exception caught = null;
 

--- a/Alluvial.Tests/QueryableTests.cs
+++ b/Alluvial.Tests/QueryableTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,8 +29,10 @@ namespace Alluvial.Tests
                     .ToArray();
             });
 
-            var catchup = stream.CreateDistributedCatchup()
-                                .DistributeInMemoryAmong(Partition.AllGuids().Among(20));
+            var catchup = stream.CreateDistributedCatchup(
+                Partition.AllGuids()
+                         .Among(20)
+                         .CreateInMemoryDistributor());
 
             var store = new InMemoryProjectionStore<int>();
 
@@ -59,8 +62,12 @@ namespace Alluvial.Tests
                     .ToArray();
             });
 
-            var catchup = stream.CreateDistributedCatchup()
-                                .DistributeInMemoryAmong(Partition.ByRange(0, 100).Among(5));
+            var distributor = Partition
+                .ByRange(0, 100)
+                .Among(5)
+                .CreateInMemoryDistributor();
+
+            var catchup = stream.CreateDistributedCatchup(distributor);
 
             var store = new InMemoryProjectionStore<int>();
 
@@ -100,8 +107,7 @@ namespace Alluvial.Tests
                     .ToArray();
             });
 
-            var catchup = stream.CreateDistributedCatchup()
-                                .DistributeInMemoryAmong(partitions);
+            var catchup = stream.CreateDistributedCatchup(partitions.CreateInMemoryDistributor());
 
             var store = new InMemoryProjectionStore<int>();
 

--- a/Alluvial.Tests/SingleStreamCatchupTests.cs
+++ b/Alluvial.Tests/SingleStreamCatchupTests.cs
@@ -523,9 +523,8 @@ namespace Alluvial.Tests
                 defaultLeaseDuration: 5.Seconds())
                                         .Trace();
 
-            var catchup = stream.CreateDistributedCatchup()
-                                .Backoff(5.Seconds())
-                                .DistributeAmong(partitions, distributor);
+            var catchup = stream.CreateDistributedCatchup(distributor)
+                                .Backoff(5.Seconds());
 
             catchup.Subscribe(async (p, b) =>
             {

--- a/Alluvial/DistributedMultiStreamCatchup{TData,TUpstreamCursor,TDownstreamCursor,TPartition}.cs
+++ b/Alluvial/DistributedMultiStreamCatchup{TData,TUpstreamCursor,TDownstreamCursor,TPartition}.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Alluvial
@@ -13,9 +12,11 @@ namespace Alluvial
 
         public DistributedMultiStreamCatchup(
             IPartitionedStream<IStream<TData, TDownstreamCursor>, TUpstreamCursor, TPartition> partitionedStream,
+            IDistributor<IStreamQueryPartition<TPartition>> distributor, 
             int? batchSize = null,
             FetchAndSave<ICursor<TUpstreamCursor>> fetchAndSavePartitionCursor = null)
             : base(null,
+                   distributor,
                    batchSize, 
                    fetchAndSavePartitionCursor)
         {

--- a/Alluvial/DistributedSingleStreamCatchup{TData,TCursor,TPartition}.cs
+++ b/Alluvial/DistributedSingleStreamCatchup{TData,TCursor,TPartition}.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -76,5 +77,15 @@ namespace Alluvial
         /// </returns>
         public override string ToString() =>
             $"{catchupTypeDescription}->{partitionedStream}->{string.Join(" + ", aggregatorSubscriptions.Select(s => s.ProjectionType.ReadableName()))}";
+
+        public void Dispose() => Distributor.Dispose();
+
+        public void OnReceive(DistributorPipeAsync<IStreamQueryPartition<TPartition>> onReceive) => Distributor.OnReceive(onReceive);
+
+        public Task Start() => Distributor.Start();
+
+        public Task<IEnumerable<IStreamQueryPartition<TPartition>>> Distribute(int count) => Distributor.Distribute(count);
+
+        public Task Stop() => Distributor.Stop();
     }
 }

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -73,6 +73,13 @@ namespace Alluvial
         }
 
         /// <summary>
+        /// Distributes all available leases.
+        /// </summary>
+        /// <param name="distributor">The distributor.</param>
+        public static async Task<IEnumerable<T>> DistributeAll<T>(this IDistributor<T> distributor) => 
+            await distributor.Distribute(int.MaxValue);
+
+        /// <summary>
         /// Wraps a distributor with tracing behaviors when leases are acquired and released.
         /// </summary>
         /// <exception cref="System.ArgumentNullException"></exception>

--- a/Alluvial/DistributorBase{T}.cs
+++ b/Alluvial/DistributorBase{T}.cs
@@ -26,7 +26,7 @@ namespace Alluvial
         /// </summary>
         /// <param name="leasables">The leasable resources to be distributed by the distributor.</param>
         /// <param name="maxDegreesOfParallelism">The maximum number of leases to be distributed at one time by this distributor instance.</param>
-        /// <param name="waitInterval">The interval to wait after a lease is released before which leased resource should not become available again.</param>
+        /// <param name="waitInterval">The interval to wait after a lease is released before which leased resource should not become available again. If not specified, the default is .5 seconds.</param>
         /// <exception cref="System.ArgumentNullException"></exception>
         /// <exception cref="System.ArgumentException">
         /// There must be at least one leasable.
@@ -42,7 +42,7 @@ namespace Alluvial
             {
                 throw new ArgumentNullException(nameof(leasables));
             }
-            if (leasables.Length ==0)
+            if (leasables.Length == 0)
             {
                 throw new ArgumentException("There must be at least one leasable.");
             }
@@ -103,6 +103,8 @@ namespace Alluvial
             EnsureOnReceiveHasBeenCalled();
 
             var acquired = new List<T>();
+
+            count = Math.Min(count, leasables.Length);
 
             while (acquired.Count < count)
             {

--- a/Alluvial/IDistributedStreamCatchup{TData,TPartition}.cs
+++ b/Alluvial/IDistributedStreamCatchup{TData,TPartition}.cs
@@ -1,9 +1,7 @@
-using System.Threading.Tasks;
-
 namespace Alluvial
 {
     public interface IDistributedStreamCatchup<out TData, TPartition> : IStreamCatchup<TData>
     {
-        Task ReceiveLease(Lease<IStreamQueryPartition<TPartition>> lease);
+        IDistributor<IStreamQueryPartition<TPartition>> Distributor { get; }
     }
 }

--- a/Alluvial/IDistributedStreamCatchup{TData,TPartition}.cs
+++ b/Alluvial/IDistributedStreamCatchup{TData,TPartition}.cs
@@ -1,7 +1,8 @@
 namespace Alluvial
 {
-    public interface IDistributedStreamCatchup<out TData, TPartition> : IStreamCatchup<TData>
+    public interface IDistributedStreamCatchup<out TData, TPartition> :
+        IStreamCatchup<TData>,
+        IDistributor<IStreamQueryPartition<TPartition>>
     {
-        IDistributor<IStreamQueryPartition<TPartition>> Distributor { get; }
     }
 }

--- a/Alluvial/StreamCatchup.cs
+++ b/Alluvial/StreamCatchup.cs
@@ -59,7 +59,7 @@ namespace Alluvial
                 throw new ArgumentNullException(nameof(catchup));
             }
 
-            catchup.Distributor.OnReceive(async (lease, next) =>
+            catchup.OnReceive(async (lease, next) =>
             {
                 using (var counter = catchup.Count())
                 {
@@ -659,7 +659,15 @@ namespace Alluvial
                 this.inner = inner;
             }
 
-            public IDistributor<IStreamQueryPartition<TPartition>> Distributor => inner.Distributor;
+            public void Dispose() => inner.Dispose();
+
+            public void OnReceive(DistributorPipeAsync<IStreamQueryPartition<TPartition>> onReceive) => inner.OnReceive(onReceive);
+
+            public Task Start() => inner.Start();
+
+            public Task<IEnumerable<IStreamQueryPartition<TPartition>>> Distribute(int count) => inner.Distribute(count);
+
+            public Task Stop() => inner.Stop();
         }
     }
 }

--- a/Alluvial/StreamCatchup.cs
+++ b/Alluvial/StreamCatchup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Alluvial
@@ -58,33 +59,21 @@ namespace Alluvial
                 throw new ArgumentNullException(nameof(catchup));
             }
 
-            return catchup.Wrap<TData, TPartition>(
-                runSingleBatch: async lease =>
+            catchup.Distributor.OnReceive(async (lease, next) =>
+            {
+                using (var counter = catchup.Count())
                 {
-                    using (var counter = catchup.Count())
-                    {
-                        await catchup.RunSingleBatch(lease);
+                    await next(lease);
 
-                        if (counter.Value == 0)
-                        {
-                            await lease.Extend(duration);
-                            await lease.Expiration();
-                        }
-                    }
-                },
-                receiveLease: async lease =>
-                {
-                    using (var counter = catchup.Count())
+                    if (counter.Value == 0)
                     {
-                        await catchup.ReceiveLease(lease);
-
-                        if (counter.Value == 0)
-                        {
-                            await lease.Extend(duration);
-                            await lease.Expiration();
-                        }
+                        await lease.Extend(duration);
+                        await lease.Expiration();
                     }
-                });
+                }
+            });
+
+            return catchup;
         }
 
         internal static Counter<TData> Count<TData>(
@@ -216,6 +205,7 @@ namespace Alluvial
         /// <remarks>If no distributor is provided, then distribution is done in-process.</remarks>
         public static IDistributedStreamCatchup<TData, TPartition> CreateDistributedCatchup<TData, TCursor, TPartition>(
             this IPartitionedStream<TData, TCursor, TPartition> streams,
+            IDistributor<IStreamQueryPartition<TPartition>> distributor,
             int? batchSize = null,
             FetchAndSave<ICursor<TCursor>> fetchAndSavePartitionCursor = null)
         {
@@ -226,6 +216,7 @@ namespace Alluvial
 
             var catchup = new DistributedSingleStreamCatchup<TData, TCursor, TPartition>(
                 streams,
+                distributor,
                 batchSize,
                 fetchAndSavePartitionCursor);
 
@@ -238,6 +229,7 @@ namespace Alluvial
         /// <remarks>If no distributor is provided, then distribution is done in-process.</remarks>
         public static IDistributedStreamCatchup<TData, TPartition> CreateDistributedCatchup<TData, TUpstreamCursor, TDownstreamCursor, TPartition>(
             this IPartitionedStream<IStream<TData, TDownstreamCursor>, TUpstreamCursor, TPartition> streams,
+            IDistributor<IStreamQueryPartition<TPartition>> distributor, 
             int? batchSize = null,
             FetchAndSave<ICursor<TUpstreamCursor>> fetchAndSavePartitionCursor = null)
         {
@@ -248,74 +240,11 @@ namespace Alluvial
 
             var catchup = new DistributedMultiStreamCatchup<TData, TUpstreamCursor, TDownstreamCursor, TPartition>(
                 streams,
+                distributor,
                 batchSize,
                 fetchAndSavePartitionCursor);
 
             return catchup;
-        }
-
-        /// <summary>
-        /// Distributes the work of querying specified partitions using a distributor.
-        /// </summary>
-        /// <typeparam name="TData">The type of the data in the stream.</typeparam>
-        /// <typeparam name="TPartition">The type of the partition.</typeparam>
-        /// <param name="catchup">The catchup.</param>
-        /// <param name="partitions">The partitions to distribute.</param>
-        /// <param name="distributor">The distributor.</param>
-        public static IDistributedStreamCatchup<TData, TPartition> DistributeAmong<TData, TPartition>(
-            this IDistributedStreamCatchup<TData, TPartition> catchup,
-            IEnumerable<IStreamQueryPartition<TPartition>> partitions,
-            IDistributor<IStreamQueryPartition<TPartition>> distributor)
-        {
-            if (catchup == null)
-            {
-                throw new ArgumentNullException(nameof(catchup));
-            }
-            if (partitions == null)
-            {
-                throw new ArgumentNullException(nameof(partitions));
-            }
-            if (distributor == null)
-            {
-                throw new ArgumentNullException(nameof(distributor));
-            }
-
-            var queryPartitions = partitions as IStreamQueryPartition<TPartition>[] ?? partitions.ToArray();
-
-            var wrapped = catchup.Wrap<TData, TPartition>(
-                runSingleBatch: lease => distributor.Distribute(queryPartitions.Length),
-                receiveLease: catchup.ReceiveLease);
-
-            distributor.OnReceive(lease => wrapped.ReceiveLease(lease));
-
-            return wrapped;
-        }
-
-        /// <summary>
-        /// Distributes the work of querying specified partitions using an in-memory distributor.
-        /// </summary>
-        /// <typeparam name="TData">The type of the data in the stream.</typeparam>
-        /// <typeparam name="TPartition">The type of the partition.</typeparam>
-        /// <param name="catchup">The catchup.</param>
-        /// <param name="partitions">The partitions to distribute.</param>
-        public static IDistributedStreamCatchup<TData, TPartition> DistributeInMemoryAmong<TData, TPartition>(
-            this IDistributedStreamCatchup<TData, TPartition> catchup,
-            IEnumerable<IStreamQueryPartition<TPartition>> partitions)
-        {
-            if (catchup == null)
-            {
-                throw new ArgumentNullException(nameof(catchup));
-            }
-            if (partitions == null)
-            {
-                throw new ArgumentNullException(nameof(partitions));
-            }
-
-            var queryPartitions = partitions as IStreamQueryPartition<TPartition>[] ?? partitions.ToArray();
-
-            var distributor = queryPartitions.CreateInMemoryDistributor();
-
-            return catchup.DistributeAmong(queryPartitions, distributor);
         }
 
         /// <summary>
@@ -647,41 +576,53 @@ namespace Alluvial
 
         internal static Wrapper<TData> Wrap<TData>(
             this IStreamCatchup<TData> innerCatchup,
-            Func<ILease, Task> runSingleBatch)
+            Func<ILease, Task> runSingleBatch,
+            [CallerMemberName] string caller = null)
         {
             return new Wrapper<TData>(innerCatchup,
-                                      runSingleBatch);
+                                      runSingleBatch,
+                                      caller);
         }
 
         internal static Wrapper<TData, TPartition> Wrap<TData, TPartition>(
-            this IStreamCatchup<TData> innerCatchup,
+            this IDistributedStreamCatchup<TData, TPartition> innerCatchup,
             Func<ILease, Task> runSingleBatch,
-            Func<Lease<IStreamQueryPartition<TPartition>>, Task> receiveLease)
+            [CallerMemberName] string caller = null)
         {
             return new Wrapper<TData, TPartition>(innerCatchup,
                                                   runSingleBatch,
-                                                  receiveLease);
+                                                  caller);
         }
 
         internal class Wrapper<TData> : IStreamCatchup<TData>
         {
-            private readonly IStreamCatchup<TData> innerCatchup;
+            private readonly IStreamCatchup<TData> inner;
             private readonly Func<ILease, Task> runSingleBatch;
+            private readonly string caller;
 
             public Wrapper(
-                IStreamCatchup<TData> innerCatchup,
-                Func<ILease, Task> runSingleBatch)
+                IStreamCatchup<TData> inner,
+                Func<ILease, Task> runSingleBatch,
+                string caller)
             {
-                if (innerCatchup == null)
+                if (inner == null)
                 {
-                    throw new ArgumentNullException(nameof(innerCatchup));
+                    throw new ArgumentNullException(nameof(inner));
                 }
                 if (runSingleBatch == null)
                 {
                     throw new ArgumentNullException(nameof(runSingleBatch));
                 }
-                this.innerCatchup = innerCatchup;
+                this.inner = inner;
                 this.runSingleBatch = runSingleBatch;
+
+                var wrapper = inner as Wrapper<TData>;
+                if (wrapper != null)
+                {
+                    caller = $"{wrapper.caller} -> {caller}";
+                }
+
+                this.caller = caller;
             }
 
             public IDisposable SubscribeAggregator<TProjection>(
@@ -689,38 +630,36 @@ namespace Alluvial
                 FetchAndSave<TProjection> fetchAndSave,
                 HandleAggregatorError<TProjection> onError)
                 =>
-                    innerCatchup.SubscribeAggregator(
-                        aggregator,
-                        fetchAndSave,
-                        onError);
+                    inner.SubscribeAggregator(aggregator,
+                                              fetchAndSave,
+                                              onError);
 
             public Task RunSingleBatch(ILease lease) => runSingleBatch(lease);
+
+            public override string ToString()
+            {
+                return $"StreamCatchup {caller}";
+            }
         }
 
         internal class Wrapper<TData, TPartition> :
             Wrapper<TData>,
             IDistributedStreamCatchup<TData, TPartition>
         {
-            private readonly Func<Lease<IStreamQueryPartition<TPartition>>, Task> receiveLease;
+            private readonly IDistributedStreamCatchup<TData, TPartition> inner;
 
             public Wrapper(
-                IStreamCatchup<TData> innerCatchup,
+                IDistributedStreamCatchup<TData, TPartition> inner,
                 Func<ILease, Task> runSingleBatch,
-                Func<Lease<IStreamQueryPartition<TPartition>>, Task> receiveLease) :
-                    base(innerCatchup,
-                         runSingleBatch)
+                string caller) :
+                    base(inner,
+                         runSingleBatch,
+                         caller)
             {
-                if (receiveLease == null)
-                {
-                    throw new ArgumentNullException(nameof(receiveLease));
-                }
-                this.receiveLease = receiveLease;
+                this.inner = inner;
             }
 
-            public Task ReceiveLease(Lease<IStreamQueryPartition<TPartition>> lease)
-            {
-                return receiveLease(lease);
-            }
+            public IDistributor<IStreamQueryPartition<TPartition>> Distributor => inner.Distributor;
         }
     }
 }


### PR DESCRIPTION
There were some awkward circular dependencies between `IDistributedStreamCatchup<TData, TPartition>` and `IDistributor<T>`. Changing the interface cleaned up the usage pattern a lot. You can see this here reflected in many tests. Another round of renames may be appropriate for some of these impacted methods. I'd love opinions on the naming.