### PR TITLE
Distributor exception improvements

### DIFF
--- a/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
+++ b/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
@@ -15,7 +15,7 @@ namespace Alluvial.Distributors.Sql
     {
         private readonly SqlBrokeredDistributorDatabase database;
         private readonly TimeSpan defaultLeaseDuration;
-        private bool isDatabaseInitialized = false;
+        private bool isDatabaseInitialized;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlBrokeredDistributor{T}"/> class.

--- a/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
+++ b/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -16,7 +15,7 @@ namespace Alluvial.Distributors.Sql
     {
         private readonly SqlBrokeredDistributorDatabase database;
         private readonly TimeSpan defaultLeaseDuration;
-        private readonly bool isDatabaseInitialized = false;
+        private bool isDatabaseInitialized = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlBrokeredDistributor{T}"/> class.
@@ -48,7 +47,7 @@ namespace Alluvial.Distributors.Sql
             {
                 throw new ArgumentNullException(nameof(database));
             }
-          
+
             this.database = database;
             this.defaultLeaseDuration = defaultLeaseDuration ?? TimeSpan.FromMinutes(5);
         }
@@ -78,68 +77,67 @@ namespace Alluvial.Distributors.Sql
         /// <returns>A task whose result is either a lease (if acquired) or null.</returns>
         protected override async Task<Lease<T>> AcquireLease()
         {
+            Lease<T> lease = null;
+
             using (var connection = new SqlConnection(database.ConnectionString))
+            using (var cmd = connection.CreateCommand())
             {
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.CommandText = @"Alluvial.AcquireLease";
+                cmd.Parameters.AddWithValue(@"@waitIntervalMilliseconds", WaitInterval.TotalMilliseconds);
+                cmd.Parameters.AddWithValue(@"@leaseDurationMilliseconds", defaultLeaseDuration.TotalMilliseconds);
+                cmd.Parameters.AddWithValue(@"@pool", Pool);
+
                 await connection.OpenAsync();
 
-                using (var cmd = connection.CreateCommand())
+                using (var reader = await cmd.ExecuteReaderAsync())
                 {
-                    cmd.CommandType = CommandType.StoredProcedure;
-                    cmd.CommandText = @"Alluvial.AcquireLease";
-                    cmd.Parameters.AddWithValue(@"@waitIntervalMilliseconds", WaitInterval.TotalMilliseconds);
-                    cmd.Parameters.AddWithValue(@"@leaseDurationMilliseconds", defaultLeaseDuration.TotalMilliseconds);
-                    cmd.Parameters.AddWithValue(@"@pool", Pool);
-
-                    using (var reader = await cmd.ExecuteReaderAsync())
+                    if (await reader.ReadAsync())
                     {
-                        while (await reader.ReadAsync())
-                        {
-                            var resourceName = await reader.GetFieldValueAsync<string>(0);
-                            var leaseLastGranted = await reader.GetFieldValueAsync<dynamic>(2);
-                            var leaseLastReleased = await reader.GetFieldValueAsync<dynamic>(3);
-                            var token = await reader.GetFieldValueAsync<dynamic>(5);
+                        var resourceName = await reader.GetFieldValueAsync<string>(0);
+                        var leaseLastGranted = await reader.GetFieldValueAsync<dynamic>(2);
+                        var leaseLastReleased = await reader.GetFieldValueAsync<dynamic>(3);
+                        var token = await reader.GetFieldValueAsync<dynamic>(5);
 
-                            var resource = Leasables.Single(l => l.Name == resourceName);
+                        var resource = Leasables.Single(l => l.Name == resourceName);
 
-                            resource.LeaseLastGranted = leaseLastGranted is DBNull
-                                                            ? DateTimeOffset.MinValue
-                                                            : (DateTimeOffset) leaseLastGranted;
-                            resource.LeaseLastReleased = leaseLastReleased is DBNull
-                                                             ? DateTimeOffset.MinValue
-                                                             : (DateTimeOffset) leaseLastReleased;
+                        resource.LeaseLastGranted = leaseLastGranted is DBNull
+                                                        ? DateTimeOffset.MinValue
+                                                        : (DateTimeOffset) leaseLastGranted;
+                        resource.LeaseLastReleased = leaseLastReleased is DBNull
+                                                         ? DateTimeOffset.MinValue
+                                                         : (DateTimeOffset) leaseLastReleased;
 
-                            Lease<T> lease = null;
-                            lease = new Lease<T>(resource,
-                                                 defaultLeaseDuration,
-                                                 (int) token,
-                                                 extend: by => ExtendLease(lease, @by));
-                            return lease;
-                        }
+                        lease = new Lease<T>(resource,
+                                             defaultLeaseDuration,
+                                             (int) token,
+                                             extend: by => ExtendLease(lease, @by));
                     }
+
+                    reader.Dispose();
+                    connection.Close();
                 }
 
-                return null;
+                return lease;
             }
         }
 
         private async Task<TimeSpan> ExtendLease(Lease<T> lease, TimeSpan by)
         {
             using (var connection = new SqlConnection(database.ConnectionString))
+            using (var cmd = connection.CreateCommand())
             {
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.CommandText = @"Alluvial.ExtendLease";
+                cmd.Parameters.AddWithValue(@"@resourceName", lease.ResourceName);
+                cmd.Parameters.AddWithValue(@"@byMilliseconds", by.TotalMilliseconds);
+                cmd.Parameters.AddWithValue(@"@token", lease.OwnerToken);
+
                 await connection.OpenAsync();
+                var newCancelationTime = (DateTimeOffset) await cmd.ExecuteScalarAsync();
+                connection.Close();
 
-                using (var cmd = connection.CreateCommand())
-                {
-                    cmd.CommandType = CommandType.StoredProcedure;
-                    cmd.CommandText = @"Alluvial.ExtendLease";
-                    cmd.Parameters.AddWithValue(@"@resourceName", lease.ResourceName);
-                    cmd.Parameters.AddWithValue(@"@byMilliseconds", by.TotalMilliseconds);
-                    cmd.Parameters.AddWithValue(@"@token", lease.OwnerToken);
-
-                    var newCancelationTime = (DateTimeOffset) await cmd.ExecuteScalarAsync();
-
-                    return newCancelationTime - DateTimeOffset.UtcNow;
-                }
+                return newCancelationTime - DateTimeOffset.UtcNow;
             }
         }
 
@@ -149,27 +147,18 @@ namespace Alluvial.Distributors.Sql
         protected override async Task ReleaseLease(Lease<T> lease)
         {
             using (var connection = new SqlConnection(database.ConnectionString))
+            using (var cmd = connection.CreateCommand())
             {
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.CommandText = @"Alluvial.ReleaseLease";
+                cmd.Parameters.AddWithValue(@"@resourceName", lease.ResourceName);
+                cmd.Parameters.AddWithValue(@"@token", lease.OwnerToken);
+
                 await connection.OpenAsync();
+                var leaseLastReleased = (DateTimeOffset) await cmd.ExecuteScalarAsync();
+                connection.Close();
 
-                using (var cmd = connection.CreateCommand())
-                {
-                    cmd.CommandType = CommandType.StoredProcedure;
-                    cmd.CommandText = @"Alluvial.ReleaseLease";
-                    cmd.Parameters.AddWithValue(@"@resourceName", lease.ResourceName);
-                    cmd.Parameters.AddWithValue(@"@token", lease.OwnerToken);
-
-                    try
-                    {
-                        var leaseLastReleased = (DateTimeOffset) await cmd.ExecuteScalarAsync();
-                        lease.NotifyReleased(leaseLastReleased);
-                        Debug.WriteLine($"[Distribute] ReleaseLease: {lease}");
-                    }
-                    catch (Exception exception)
-                    {
-                        Debug.WriteLine($"[Distribute] ReleaseLease (failed): {lease}\n{exception}");
-                    }
-                }
+                lease.NotifyReleased(leaseLastReleased);
             }
         }
 
@@ -184,6 +173,8 @@ namespace Alluvial.Distributors.Sql
             await database.RegisterLeasableResources(
                 Leasables,
                 Pool);
+
+            isDatabaseInitialized = true;
         }
     }
 }

--- a/Alluvial.Distributors.Sql/SqlBrokeredDistributorDatabase.cs
+++ b/Alluvial.Distributors.Sql/SqlBrokeredDistributorDatabase.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/Alluvial.Tests/Alluvial.Tests.csproj
+++ b/Alluvial.Tests/Alluvial.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="BankDomain\AccountOpened.cs" />
     <Compile Include="BankDomain\BankAccountType.cs" />
     <Compile Include="BankDomain\Projections\AccountHistoryProjector.cs" />
+    <Compile Include="Distributors\DistributorBaseTests.cs" />
     <Compile Include="GuidPartioningTests.cs" />
     <Compile Include="Infrastructure\AlluvialSqlTestsDbContext.cs" />
     <Compile Include="Infrastructure\AsyncBarrier.cs" />

--- a/Alluvial.Tests/Distributors/DistributorBaseTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorBaseTests.cs
@@ -10,15 +10,21 @@ namespace Alluvial.Tests.Distributors
     [TestFixture]
     public class DistributorBaseTests
     {
+        private Leasable<int>[] leasables;
+
+        [SetUp]
+        public void SetUp()
+        {
+            leasables = Enumerable.Range(1, 10)
+                                  .Select(i => new Leasable<int>(i, i.ToString()))
+                                  .ToArray();
+        }
+
         [Test]
         public async Task An_exception_during_AcquireLease_doesnt_stop_the_distributor()
         {
             var acquireCount = 0;
             var receiveCount = 0;
-
-            var leasables = Enumerable.Range(1, 10)
-                                      .Select(i => new Leasable<int>(i, i.ToString()))
-                                      .ToArray();
 
             var distributor = new TestDistributor<int>(
                 leasables,
@@ -44,10 +50,6 @@ namespace Alluvial.Tests.Distributors
         {
             var releaseCount = 0;
             var receiveCount = 0;
-
-            var leasables = Enumerable.Range(1, 10)
-                                      .Select(i => new Leasable<int>(i, i.ToString()))
-                                      .ToArray();
 
             var distributor = new TestDistributor<int>(
                 leasables,
@@ -97,7 +99,6 @@ namespace Alluvial.Tests.Distributors
         {
             await beforeAcquire();
             return await base.AcquireLease();
-            ;
         }
     }
 }

--- a/Alluvial.Tests/Distributors/DistributorBaseTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorBaseTests.cs
@@ -1,0 +1,74 @@
+using System;
+using FluentAssertions;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Alluvial.Tests.Distributors
+{
+    [TestFixture]
+    public class DistributorBaseTests
+    {
+        [Test]
+        public async Task An_exception_during_AcquireLease_doesnt_stop_the_distributor()
+        {
+            var acquireCount = 0;
+            var receiveCount = 0;
+
+            var leasables = Enumerable.Range(1, 10)
+                                      .Select(i => new Leasable<int>(i, i.ToString()))
+                                      .ToArray();
+
+            var distributor = new TestDistributor<int>(
+                leasables,
+                beforeAcquire: async () =>
+                {
+                    if (Interlocked.Increment(ref acquireCount) == 2)
+                    {
+                        throw new Exception("dang!");
+                    }
+                }).Trace();
+
+            distributor.OnReceive(async (lease, next) => { Interlocked.Increment(ref receiveCount); });
+
+            await distributor.Start();
+
+            await Task.Delay(100);
+
+            receiveCount.Should().BeGreaterThan(5);
+        }
+    }
+
+    public class TestDistributor<T> : InMemoryDistributor<T>
+    {
+        private readonly Func<Task> beforeAcquire;
+        private readonly Func<Lease<T>, Task> beforeRelease;
+
+        public TestDistributor(
+            Leasable<T>[] leasables,
+            Func<Task> beforeAcquire = null,
+            Func<Lease<T>, Task> beforeRelease = null,
+            string pool = "default",
+            int maxDegreesOfParallelism = 5,
+            TimeSpan? waitInterval = null) :
+                base(leasables, pool, maxDegreesOfParallelism, waitInterval)
+        {
+            this.beforeAcquire = beforeAcquire ?? (async () => { });
+            this.beforeRelease = beforeRelease ?? (async lease => { });
+        }
+
+        protected override async Task ReleaseLease(Lease<T> lease)
+        {
+            await beforeRelease(lease);
+            await base.ReleaseLease(lease);
+        }
+
+        protected override async Task<Lease<T>> AcquireLease()
+        {
+            await beforeAcquire();
+            return await base.AcquireLease();
+            ;
+        }
+    }
+}

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -424,7 +424,6 @@ namespace Alluvial.Tests.Distributors
             receivedLeases.Count().Should().Be(10);
         }
 
-
         [Test]
         public async Task Distribute_will_not_distribute_more_leases_than_there_are_leasables()
         {

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -162,14 +162,6 @@ namespace Alluvial.Tests.Distributors
             received.Should().BeGreaterOrEqualTo(20);
         }
 
-        [Ignore("Test not finished")]
-        [Test]
-        public async Task When_receiver_throws_then_the_exception_can_be_observed()
-        {
-            // FIX (When_receiver_throws_then_the_exception_can_be_observed) write test
-            Assert.Fail("Test not written yet.");
-        }
-
         [Test]
         public async Task A_wait_interval_can_be_specified_before_which_a_released_lease_will_be_granted_again()
         {

--- a/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
@@ -20,7 +20,7 @@ namespace Alluvial.Tests.Distributors
                 leasables ?? DefaultLeasables,
                 pool ?? DateTimeOffset.UtcNow.Ticks.ToString(),
                 maxDegreesOfParallelism,
-                waitInterval,
+                waitInterval ?? TimeSpan.FromSeconds(.5),
                 DefaultLeaseDuration);
             if (onReceive != null)
             {

--- a/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Alluvial.Distributors.Sql;
@@ -31,7 +30,7 @@ namespace Alluvial.Tests.Distributors
                 Database,
                 pool,
                 maxDegreesOfParallelism,
-                waitInterval,
+                waitInterval ?? TimeSpan.FromSeconds(1),
                 DefaultLeaseDuration);
 
             if (onReceive != null)

--- a/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Alluvial.Distributors.Sql;
 using FluentAssertions;

--- a/Alluvial/AnonymousDistributor.cs
+++ b/Alluvial/AnonymousDistributor.cs
@@ -8,6 +8,7 @@ namespace Alluvial
     {
         private readonly Func<Task> start;
         private readonly Action<DistributorPipeAsync<T>> onReceive;
+        private readonly Action<Action<Exception, Lease<T>>> onException;
         private readonly Func<Task> stop;
         private readonly Func<int, Task<IEnumerable<T>>> distribute;
 
@@ -15,7 +16,7 @@ namespace Alluvial
             Func<Task> start,
             Action<DistributorPipeAsync<T>> onReceive,
             Func<Task> stop,
-            Func<int, Task<IEnumerable<T>>> distribute)
+            Func<int, Task<IEnumerable<T>>> distribute, Action<Action<Exception, Lease<T>>> onException)
         {
             if (start == null)
             {
@@ -39,12 +40,15 @@ namespace Alluvial
             this.onReceive = onReceive;
             this.stop = stop;
             this.distribute = distribute;
+            this.onException = onException;
         }
 
-        public void OnReceive(DistributorPipeAsync<T> receive)
-        {
+        public void OnReceive(DistributorPipeAsync<T> receive) => 
             onReceive(receive);
-        }
+
+        public void OnException(Action<Exception, Lease<T>> notify) =>
+            onException(notify);
+     
 
         public Task Start() => start();
 

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -17,6 +17,7 @@ namespace Alluvial
         /// <typeparam name="T">The type of the distributed resource.</typeparam>
         /// <param name="start">A delegate that when called starts the distributor.</param>
         /// <param name="onReceive">A delegate to be called when a lease becomes available.</param>
+        /// <param name="onException">A delegate to be called when the distributor catches an exception while acquiring, distributing, or releasing a lease.</param>
         /// <param name="stop">A delegate that when called stops the distributor.</param>
         /// <param name="distribute">A delegate that when called distributes the specified number of leases.</param>
         /// <returns>An anonymous distributor instance.</returns>
@@ -24,8 +25,9 @@ namespace Alluvial
             Func<Task> start,
             Action<DistributorPipeAsync<T>> onReceive,
             Func<Task> stop,
-            Func<int, Task<IEnumerable<T>>> distribute) =>
-                new AnonymousDistributor<T>(start, onReceive, stop, distribute);
+            Func<int, Task<IEnumerable<T>>> distribute,
+            Action<Action<Exception, Lease<T>>> onException) =>
+                new AnonymousDistributor<T>(start, onReceive, stop, distribute, onException);
 
         /// <summary>
         /// Creates an in-memory distributor.
@@ -86,22 +88,27 @@ namespace Alluvial
         public static IDistributor<T> Trace<T>(
             this IDistributor<T> distributor,
             Action<Lease<T>> onLeaseAcquired = null,
-            Action<Lease<T>> onLeaseReleasing = null)
+            Action<Lease<T>> onLeaseReleasing = null,
+            Action<Exception, Lease<T>> onException = null)
         {
             if (distributor == null)
             {
                 throw new ArgumentNullException(nameof(distributor));
             }
 
-            if (onLeaseAcquired == null && onLeaseReleasing == null)
+            if (onLeaseAcquired == null &&
+                onLeaseReleasing == null &&
+                onException == null)
             {
                 onLeaseAcquired = lease => TraceOnLeaseAcquired(distributor, lease);
                 onLeaseReleasing = lease => TraceOnLeaseReleasing(distributor, lease);
+                onException = (exception, lease) => TraceOnException(distributor, exception, lease);
             }
             else
             {
                 onLeaseAcquired = onLeaseAcquired ?? (l => { });
                 onLeaseReleasing = onLeaseReleasing ?? (l => { });
+                onException = onException ?? ((exception, lease) => { });
             }
 
             var newDistributor = Create(
@@ -116,30 +123,8 @@ namespace Alluvial
                     return distributor.Stop();
                 },
                 distribute: distributor.Distribute,
-                onReceive: @async =>
-                {
-                    // when someone calls OnReceive on the AnonymousDistributor, pass the call along to the wrapped distributor...
-                    distributor.OnReceive(@async);
-
-                    // ... then add another call to the pipeline to check for exceptions
-                    distributor.OnReceive(async (lease, next) =>
-                    {
-                        try
-                        {
-                            await next(lease);
-
-                            if (lease.Exception != null)
-                            {
-                                WriteLine($"[Distribute] {distributor}: Exception: {lease.Exception}");
-                            }
-                        }
-                        catch (Exception exception)
-                        {
-                            WriteLine($"[Distribute] {distributor}: Exception: {exception}");
-                            throw;
-                        }
-                    });
-                });
+                onReceive: distributor.OnReceive,
+                onException: distributor.OnException);
 
             distributor.OnReceive(async (lease, next) =>
             {
@@ -148,9 +133,31 @@ namespace Alluvial
                 onLeaseReleasing(lease);
             });
 
+            distributor.OnException(onException);
+
             return newDistributor;
         }
 
+        private static void TraceOnException<T>(
+            IDistributor<T> distributor,
+            Exception exception,
+            Lease<T> lease)
+        {
+            if (lease != null)
+            {
+                WriteLine($"[Distribute] {distributor}: Exception: {lease.Exception}");
+            }
+            else if (exception != null)
+            {
+                WriteLine($"[Distribute] {distributor}: Exception: {exception}");
+            }
+        }
+
+        /// <summary>
+        /// Specifies a delegate to be called when a lease is available.
+        /// </summary>
+        /// <param name="receive">The delegate called when work is available to be done.</param>
+        /// <remarks>For the duration of the lease, the leased resource will not be available to any other instance.</remarks>
         public static void OnReceive<T>(
             this IDistributor<T> distributor,
             Func<Lease<T>, Task> receive)

--- a/Alluvial/IDistributor{T}.cs
+++ b/Alluvial/IDistributor{T}.cs
@@ -17,6 +17,14 @@ namespace Alluvial
         void OnReceive(DistributorPipeAsync<T> onReceive);
 
         /// <summary>
+        ///  Specifies a delegate to be called when an exception is thrown when acquiring, distributing out, or releasing a lease.
+        /// </summary>
+        /// <remarks>
+        /// The lease argument may be null if the exception occurs during lease acquisition.
+        /// </remarks>
+        void OnException(Action<Exception, Lease<T>> onException);
+
+        /// <summary>
         /// Starts distributing work.
         /// </summary>
         Task Start();

--- a/Alluvial/StreamCatchup.cs
+++ b/Alluvial/StreamCatchup.cs
@@ -663,6 +663,8 @@ namespace Alluvial
 
             public void OnReceive(DistributorPipeAsync<IStreamQueryPartition<TPartition>> onReceive) => inner.OnReceive(onReceive);
 
+            public void OnException(Action<Exception, Lease<IStreamQueryPartition<TPartition>>> onException) => inner.OnException(onException);
+
             public Task Start() => inner.Start();
 
             public Task<IEnumerable<IStreamQueryPartition<TPartition>>> Distribute(int count) => inner.Distribute(count);


### PR DESCRIPTION
This adds better visibility into exceptions that are caught by distributors. Since distributors handle many exceptions in order to keep on distributing in the face of adversity, I provided a back channel to observe when this happens.