### PR TITLE
Change lease release behavior

### DIFF
--- a/Alluvial.Distributors.Sql/Alluvial.Distributors.Sql.nuspec
+++ b/Alluvial.Distributors.Sql/Alluvial.Distributors.Sql.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Alluvial.Distributors.Sql</id>
     <title>Alluvial.Distributors.Sql</title>
-    <version>0.2.5</version>
+    <version>0.3.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/Alluvial</projectUrl>
@@ -13,7 +13,7 @@
     <description>A SQL-based query distributor for Alluvial</description>
     <tags>data projections stream-processing</tags>
     <dependencies>
-        <dependency id="Alluvial" version="[0.2.5,)" />
+        <dependency id="Alluvial" version="[0.3.0,)" />
     </dependencies>
 </metadata>
 </package>

--- a/Alluvial.Distributors.Sql/Distributor.cs
+++ b/Alluvial.Distributors.Sql/Distributor.cs
@@ -15,7 +15,6 @@ namespace Alluvial.Distributors.Sql
         /// <param name="partitions">The partitions to be leased out.</param>
         /// <param name="database">The database where the leases are stored.</param>
         /// <param name="pool">The pool.</param>
-        ///   /// <param name="waitInterval">The interval to wait after a lease is released before which leased resource should not become available again. If not specified, the default is .5 seconds.</param>
         /// <param name="defaultLeaseDuration">The default duration of a lease. If not specified, the default duration is five minutes.</param>
         /// <param name="maxDegreesOfParallelism">The maximum number of leases to be distributed at one time by this distributor instance.</param>
         /// <exception cref="System.ArgumentNullException">
@@ -25,7 +24,6 @@ namespace Alluvial.Distributors.Sql
             SqlBrokeredDistributorDatabase database,
             string pool,
             int maxDegreesOfParallelism = 5,
-            TimeSpan? waitInterval = null,
             TimeSpan? defaultLeaseDuration = null)
         {
             if (partitions == null)
@@ -48,7 +46,6 @@ namespace Alluvial.Distributors.Sql
                 database,
                 pool,
                 maxDegreesOfParallelism,
-                waitInterval,
                 defaultLeaseDuration);
 
             return distributor;

--- a/Alluvial.Distributors.Sql/Properties/AssemblyInfo.cs
+++ b/Alluvial.Distributors.Sql/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -12,14 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2016 Jon Sequeira")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0a610216-4ec8-4058-9c71-1d74bd7cdc8a")]
 
 [assembly: AssemblyVersion("0.3.0")]
 [assembly: AssemblyInformationalVersion("0.3.0")]

--- a/Alluvial.Distributors.Sql/Properties/AssemblyInfo.cs
+++ b/Alluvial.Distributors.Sql/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0a610216-4ec8-4058-9c71-1d74bd7cdc8a")]
 
-[assembly: AssemblyVersion("0.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.5")]
+[assembly: AssemblyVersion("0.3.0")]
+[assembly: AssemblyInformationalVersion("0.3.0")]

--- a/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
+++ b/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
@@ -108,7 +108,8 @@ namespace Alluvial.Distributors.Sql
                         lease = new Lease<T>(resource,
                                              defaultLeaseDuration,
                                              (int) token,
-                                             extend: by => ExtendLease(lease, @by));
+                                             extend: by => ExtendLease(lease, @by),
+                                             release: () => ReleaseLease(lease));
                     }
 
                     reader.Dispose();

--- a/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
+++ b/Alluvial.Distributors.Sql/SqlBrokeredDistributor.cs
@@ -24,7 +24,6 @@ namespace Alluvial.Distributors.Sql
         /// <param name="database">The database where the leases are stored.</param>
         /// <param name="pool">The name of the pool of leasable resources from which leases are acquired.</param>
         /// <param name="maxDegreesOfParallelism">The maximum number of leases to be distributed at one time by this distributor instance.</param>
-        /// <param name="waitInterval">The interval to wait after a lease is released before which leased resource should not become available again. If not specified, the default is 5 seconds.</param>
         /// <param name="defaultLeaseDuration">The default duration of a lease. If not specified, the default duration is five minutes.</param>
         /// <exception cref="System.ArgumentNullException">
         /// database
@@ -36,12 +35,10 @@ namespace Alluvial.Distributors.Sql
             SqlBrokeredDistributorDatabase database,
             string pool,
             int maxDegreesOfParallelism = 5,
-            TimeSpan? waitInterval = null,
             TimeSpan? defaultLeaseDuration = null)
             : base(leasables,
                    pool,
-                   maxDegreesOfParallelism,
-                   waitInterval)
+                   maxDegreesOfParallelism)
         {
             if (database == null)
             {
@@ -84,11 +81,11 @@ namespace Alluvial.Distributors.Sql
             {
                 cmd.CommandType = CommandType.StoredProcedure;
                 cmd.CommandText = @"Alluvial.AcquireLease";
-                cmd.Parameters.AddWithValue(@"@waitIntervalMilliseconds", WaitInterval.TotalMilliseconds);
+                cmd.Parameters.AddWithValue(@"@waitIntervalMilliseconds", 0);
                 cmd.Parameters.AddWithValue(@"@leaseDurationMilliseconds", defaultLeaseDuration.TotalMilliseconds);
                 cmd.Parameters.AddWithValue(@"@pool", Pool);
 
-                await connection.OpenAsync(backoff: WaitInterval);
+                await connection.OpenAsync(backoff: TimeSpan.FromSeconds(1));
 
                 using (var reader = await cmd.ExecuteReaderAsync())
                 {

--- a/Alluvial.For.ItsDomainSql.Tests/CommandSchedulerTests.cs
+++ b/Alluvial.For.ItsDomainSql.Tests/CommandSchedulerTests.cs
@@ -58,8 +58,7 @@ namespace Alluvial.For.ItsDomainSql.Tests
 
             var distributor = partitionsByAggregateId.CreateSqlBrokeredDistributor(
                 new SqlBrokeredDistributorDatabase(CommandSchedulerConnectionString),
-                commandsDue.Id, 
-                waitInterval: TimeSpan.FromSeconds(.5));
+                commandsDue.Id);
 
             var catchup = commandsDue
                 .CreateDistributedCatchup(distributor);
@@ -101,8 +100,7 @@ namespace Alluvial.For.ItsDomainSql.Tests
             var distributor = partitionsByAggregateId
                 .CreateSqlBrokeredDistributor(
                     new SqlBrokeredDistributorDatabase(CommandSchedulerConnectionString),
-                    commandsDue.Id,
-                    waitInterval: TimeSpan.FromSeconds(.5))
+                    commandsDue.Id)
                 .KeepClockUpdated();
 
             var catchup = commandsDue

--- a/Alluvial.For.ItsDomainSql.Tests/DatabaseSetupTests.cs
+++ b/Alluvial.For.ItsDomainSql.Tests/DatabaseSetupTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Alluvial.Distributors.Sql;
+using Its.Log.Instrumentation;
 using Microsoft.Its.Domain.Sql;
 using Microsoft.Its.Domain.Sql.Migrations;
 using NUnit.Framework;
@@ -21,7 +22,15 @@ namespace Alluvial.For.ItsDomainSql.Tests
         [SetUp]
         public void SetUp()
         {
-            Database.Delete(SchemaTestDbContext.ConnectionString);
+            try
+            {
+                Database.Delete(SchemaTestDbContext.ConnectionString);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToLogString());
+                throw;
+            }
         }
 
         [Test]

--- a/Alluvial.For.ItsDomainSql.Tests/ProjectionTests.cs
+++ b/Alluvial.For.ItsDomainSql.Tests/ProjectionTests.cs
@@ -102,7 +102,7 @@ namespace Alluvial.For.ItsDomainSql.Tests
             var distributor = Partition.AllGuids()
                                        .Among(10)
                                        .CreateInMemoryDistributor()
-                                       .AutoReleaseLeases();
+                                       .ReleaseLeasesWhenWorkIsDone();
 
             var catchup = streams.CreateDistributedCatchup(distributor);
 

--- a/Alluvial.For.ItsDomainSql.Tests/ProjectionTests.cs
+++ b/Alluvial.For.ItsDomainSql.Tests/ProjectionTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Its.Domain;
 using Microsoft.Its.Domain.Sql;
 using Microsoft.Its.Domain.Testing;
 using NUnit.Framework;
-using Pocket;
 
 namespace Alluvial.For.ItsDomainSql.Tests
 {
@@ -102,14 +101,16 @@ namespace Alluvial.For.ItsDomainSql.Tests
 
             var distributor = Partition.AllGuids()
                                        .Among(10)
-                                       .CreateInMemoryDistributor();
+                                       .CreateInMemoryDistributor()
+                                       .AutoReleaseLeases();
 
             var catchup = streams.CreateDistributedCatchup(distributor);
 
             var store = new InMemoryProjectionStore<MatchingEvents>();
             catchup.Subscribe(aggregator, store.Trace());
 
-            await catchup.RunUntilCaughtUp();
+            await catchup.RunUntilCaughtUp().Timeout();
+
             store.Sum(x => x.Value.Count).Should().Be(expectedCount);
         }
 
@@ -136,7 +137,7 @@ namespace Alluvial.For.ItsDomainSql.Tests
             var store = new InMemoryProjectionStore<Projection<int, long>>();
             catchup.Subscribe(aggregator, store);
 
-            await catchup.RunUntilCaughtUp().TimeoutAfter(DefaultTimeout());
+            await catchup.RunUntilCaughtUp().Timeout();
 
             store.Select(p => p.CursorPosition).Should().OnlyContain(i => i > 100);
         }
@@ -176,7 +177,7 @@ namespace Alluvial.For.ItsDomainSql.Tests
                               store.AsHandler(),
                               onError: error => { error.Continue(); });
 
-            await catchup.RunUntilCaughtUp().TimeoutAfter(DefaultTimeout());
+            await catchup.RunUntilCaughtUp().Timeout();
 
             store.Select(p => p.CursorPosition).Single().Should().Be(6);
         }
@@ -237,7 +238,7 @@ namespace Alluvial.For.ItsDomainSql.Tests
                 }
             });
 
-            await catchup.RunSingleBatch();
+            await catchup.RunSingleBatch().Timeout();
 
             eventsReceived.Should().HaveCount(eventStream.Count());
         }
@@ -665,11 +666,6 @@ namespace Alluvial.For.ItsDomainSql.Tests
                     Body = "{}"
                 }
             };
-        }
-
-        private TimeSpan DefaultTimeout()
-        {
-            return TimeSpan.FromSeconds(5*(Debugger.IsAttached ? 100 : 1));
         }
 
         private async Task WriteEvents<TEvent>(params Guid[] aggregateIds) where TEvent : IEvent, new()

--- a/Alluvial.For.ItsDomainSql/Alluvial.For.ItsDomainSql.nuspec
+++ b/Alluvial.For.ItsDomainSql/Alluvial.For.ItsDomainSql.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Alluvial.For.ItsDomainSql</id>
     <title>Alluvial for Its.Domain.Sql</title>
-    <version>0.2.5</version>
+    <version>0.3.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/Alluvial</projectUrl>
@@ -13,7 +13,7 @@
     <description>Build projections and deliver scheduled commands for Its.Domain using SQL and Alluvial.</description>
     <tags>data projections stream-processing CQRS Its.Cqrs Its.Domain event-sourcing</tags>
     <dependencies>
-        <dependency id="Alluvial" version="[0.2.5,)" />
+        <dependency id="Alluvial" version="[0.3.0,)" />
         <dependency id="Its.Domain" version="[0.15.2,)" />
         <dependency id="Its.Domain.Sql" version="[0.15.2,)" />
     </dependencies>

--- a/Alluvial.For.ItsDomainSql/Properties/AssemblyInfo.cs
+++ b/Alluvial.For.ItsDomainSql/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.5")]
+[assembly: AssemblyVersion("0.3.0")]
+[assembly: AssemblyInformationalVersion("0.3.0")]

--- a/Alluvial.For.ItsDomainSql/Properties/AssemblyInfo.cs
+++ b/Alluvial.For.ItsDomainSql/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -13,23 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("08044324-57d2-42fe-b2f5-f4ba6adcca1b")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.3.0")]
 [assembly: AssemblyInformationalVersion("0.3.0")]

--- a/Alluvial.Tests/BankDomain/Projections/BalanceProjector.cs
+++ b/Alluvial.Tests/BankDomain/Projections/BalanceProjector.cs
@@ -10,6 +10,12 @@ namespace Alluvial.Tests.BankDomain
             var eventsArray = events.ToArray();
             balanceProjection.Balance += eventsArray.OfType<FundsDeposited>().Sum(f => f.Amount);
             balanceProjection.Balance -= eventsArray.OfType<FundsWithdrawn>().Sum(f => f.Amount);
+
+            balanceProjection.Value = events
+                .Select(e => e.AggregateId)
+                .Distinct()
+                .SingleOrDefault();
+
             return balanceProjection;
         }
     }

--- a/Alluvial.Tests/BankDomain/Projections/ProjectionBase.cs
+++ b/Alluvial.Tests/BankDomain/Projections/ProjectionBase.cs
@@ -1,6 +1,6 @@
 ﻿namespace Alluvial.Tests.BankDomain
 {
-    public class ProjectionBase : Projection<IDomainEvent, int>
+    public class ProjectionBase : Projection<string, int>
     {
     }
 }

--- a/Alluvial.Tests/Distributors/DistributorBaseTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorBaseTests.cs
@@ -1,7 +1,6 @@
 using System;
 using FluentAssertions;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -83,9 +82,9 @@ namespace Alluvial.Tests.Distributors
             Leasable<T>[] leasables,
             Func<Task> beforeAcquire = null,
             Func<Lease<T>, Task> beforeRelease = null,
-            [CallerMemberName] string pool = null,
+            string pool = null,
             int maxDegreesOfParallelism = 5) :
-                base(leasables, pool, maxDegreesOfParallelism)
+                base(leasables, pool ?? Guid.NewGuid().ToString(), maxDegreesOfParallelism)
         {
             this.beforeAcquire = beforeAcquire ?? (async () => { });
             this.beforeRelease = beforeRelease ?? (async lease => { });

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -17,7 +17,9 @@ namespace Alluvial.Tests.Distributors
             Func<Lease<int>, Task> onReceive = null,
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 5,
-            string pool = null);
+            string pool = null,
+            TimeSpan? defaultLeaseDuration = null,
+            bool autoRelease = true);
 
         protected abstract TimeSpan DefaultLeaseDuration { get; }
 
@@ -139,7 +141,7 @@ namespace Alluvial.Tests.Distributors
         public async Task When_receiver_throws_then_work_distribution_continues()
         {
             var received = 0;
-            var distributor = CreateDistributor().Trace();
+            var distributor = CreateDistributor(defaultLeaseDuration: 1.Seconds()).Trace();
             var countdown = new AsyncCountdownEvent(20);
 
             distributor.OnReceive(async lease =>
@@ -399,12 +401,12 @@ namespace Alluvial.Tests.Distributors
 
             var distributor = CreateDistributor(
                 async lease => receivedLeases.Add(lease),
-                maxDegreesOfParallelism: 10);
+                maxDegreesOfParallelism: 10,
+                autoRelease: false);
 
             distributor.OnReceive(async lease =>
             {
                 await lease.Extend(2.Seconds());
-                await Task.Delay(2.Seconds());
             });
 
             await distributor.Start();

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -18,8 +18,7 @@ namespace Alluvial.Tests.Distributors
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 5,
             string pool = null,
-            TimeSpan? defaultLeaseDuration = null,
-            bool autoRelease = true);
+            TimeSpan? defaultLeaseDuration = null);
 
         protected abstract TimeSpan DefaultLeaseDuration { get; }
 
@@ -141,7 +140,7 @@ namespace Alluvial.Tests.Distributors
         public async Task When_receiver_throws_then_work_distribution_continues()
         {
             var received = 0;
-            var distributor = CreateDistributor(defaultLeaseDuration: 1.Seconds()).Trace();
+            var distributor = CreateDistributor(defaultLeaseDuration: 1.Seconds()).Trace().AutoReleaseLeases();
             var countdown = new AsyncCountdownEvent(20);
 
             distributor.OnReceive(async lease =>
@@ -401,8 +400,7 @@ namespace Alluvial.Tests.Distributors
 
             var distributor = CreateDistributor(
                 async lease => receivedLeases.Add(lease),
-                maxDegreesOfParallelism: 10,
-                autoRelease: false);
+                maxDegreesOfParallelism: 10);
 
             distributor.OnReceive(async lease =>
             {

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -393,7 +393,7 @@ namespace Alluvial.Tests.Distributors
         }
 
         [Test]
-        public async Task Distributor_rate_can_be_slowed()
+        public async Task Distributor_rate_can_be_slowed_by_extending_leases()
         {
             var receivedLeases = new ConcurrentBag<Lease<int>>();
 

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -140,7 +140,7 @@ namespace Alluvial.Tests.Distributors
         public async Task When_receiver_throws_then_work_distribution_continues()
         {
             var received = 0;
-            var distributor = CreateDistributor(defaultLeaseDuration: 1.Seconds()).Trace().AutoReleaseLeases();
+            var distributor = CreateDistributor(defaultLeaseDuration: 1.Seconds()).Trace().ReleaseLeasesWhenWorkIsDone();
             var countdown = new AsyncCountdownEvent(20);
 
             distributor.OnReceive(async lease =>

--- a/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
@@ -13,13 +13,19 @@ namespace Alluvial.Tests.Distributors
             Func<Lease<int>, Task> onReceive = null,
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 5,
-            string pool = null)
+            string pool = null,
+            TimeSpan? defaultLeaseDuration = null,
+            bool autoRelease = true)
         {
             distributor = new InMemoryDistributor<int>(
                 leasables ?? DefaultLeasables,
                 pool ?? DateTimeOffset.UtcNow.Ticks.ToString(),
                 maxDegreesOfParallelism,
-                DefaultLeaseDuration);
+                 defaultLeaseDuration ?? DefaultLeaseDuration)
+            {
+                AutoReleaseLeases = autoRelease
+            };
+
             if (onReceive != null)
             {
                 distributor.OnReceive(onReceive);

--- a/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -13,14 +14,12 @@ namespace Alluvial.Tests.Distributors
             Func<Lease<int>, Task> onReceive = null,
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 5,
-            TimeSpan? waitInterval = null,
-            string pool = null)
+            [CallerMemberName] string pool = null)
         {
             distributor = new InMemoryDistributor<int>(
                 leasables ?? DefaultLeasables,
                 pool ?? DateTimeOffset.UtcNow.Ticks.ToString(),
                 maxDegreesOfParallelism,
-                waitInterval ?? TimeSpan.FromSeconds(.5),
                 DefaultLeaseDuration);
             if (onReceive != null)
             {

--- a/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
@@ -30,6 +30,7 @@ namespace Alluvial.Tests.Distributors
             {
                 distributor.OnReceive(onReceive);
             }
+
             return distributor;
         }
 

--- a/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -14,7 +13,7 @@ namespace Alluvial.Tests.Distributors
             Func<Lease<int>, Task> onReceive = null,
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 5,
-            [CallerMemberName] string pool = null)
+            string pool = null)
         {
             distributor = new InMemoryDistributor<int>(
                 leasables ?? DefaultLeasables,

--- a/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/InMemoryDistributorTests.cs
@@ -14,17 +14,13 @@ namespace Alluvial.Tests.Distributors
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 5,
             string pool = null,
-            TimeSpan? defaultLeaseDuration = null,
-            bool autoRelease = true)
+            TimeSpan? defaultLeaseDuration = null)
         {
             distributor = new InMemoryDistributor<int>(
                 leasables ?? DefaultLeasables,
                 pool ?? DateTimeOffset.UtcNow.Ticks.ToString(),
                 maxDegreesOfParallelism,
-                 defaultLeaseDuration ?? DefaultLeaseDuration)
-            {
-                AutoReleaseLeases = autoRelease
-            };
+                 defaultLeaseDuration ?? DefaultLeaseDuration);
 
             if (onReceive != null)
             {

--- a/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
@@ -21,7 +21,9 @@ namespace Alluvial.Tests.Distributors
             Func<Lease<int>, Task> onReceive = null,
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 1,
-            string pool = null)
+            string pool = null,
+            TimeSpan? defaultLeaseDuration = null,
+            bool autoRelease = true)
         {
             leasables = leasables ?? DefaultLeasables;
 
@@ -39,7 +41,10 @@ namespace Alluvial.Tests.Distributors
                 Database,
                 pool,
                 maxDegreesOfParallelism,
-                DefaultLeaseDuration);
+                defaultLeaseDuration ?? DefaultLeaseDuration)
+            {
+                AutoReleaseLeases = autoRelease
+            };
 
             if (onReceive != null)
             {

--- a/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
@@ -1,8 +1,6 @@
 using System;
 using Alluvial.Distributors.Sql;
 using FluentAssertions;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -23,11 +21,13 @@ namespace Alluvial.Tests.Distributors
             Func<Lease<int>, Task> onReceive = null,
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 1,
-            [CallerMemberName] string pool = null)
+            string pool = null)
         {
             leasables = leasables ?? DefaultLeasables;
 
-            pool = pool ?? DateTimeOffset.UtcNow.Ticks.ToString();
+            pool = pool ?? Guid.NewGuid().ToString();
+
+            Console.WriteLine(new { pool });
 
             if (pool.Length > 75)
             {

--- a/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
@@ -2,6 +2,7 @@ using System;
 using Alluvial.Distributors.Sql;
 using FluentAssertions;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -22,19 +23,22 @@ namespace Alluvial.Tests.Distributors
             Func<Lease<int>, Task> onReceive = null,
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 1,
-            TimeSpan? waitInterval = null,
-            string pool = null)
+            [CallerMemberName] string pool = null)
         {
             leasables = leasables ?? DefaultLeasables;
 
             pool = pool ?? DateTimeOffset.UtcNow.Ticks.ToString();
+
+            if (pool.Length > 75)
+            {
+                pool = pool.Substring(0, 75);
+            }
 
             distributor = new SqlBrokeredDistributor<int>(
                 leasables,
                 Database,
                 pool,
                 maxDegreesOfParallelism,
-                waitInterval ?? TimeSpan.FromSeconds(1),
                 DefaultLeaseDuration);
 
             if (onReceive != null)

--- a/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
+++ b/Alluvial.Tests/Distributors/SqlBrokeredDistributorTests.cs
@@ -22,8 +22,7 @@ namespace Alluvial.Tests.Distributors
             Leasable<int>[] leasables = null,
             int maxDegreesOfParallelism = 1,
             string pool = null,
-            TimeSpan? defaultLeaseDuration = null,
-            bool autoRelease = true)
+            TimeSpan? defaultLeaseDuration = null)
         {
             leasables = leasables ?? DefaultLeasables;
 
@@ -41,10 +40,7 @@ namespace Alluvial.Tests.Distributors
                 Database,
                 pool,
                 maxDegreesOfParallelism,
-                defaultLeaseDuration ?? DefaultLeaseDuration)
-            {
-                AutoReleaseLeases = autoRelease
-            };
+                defaultLeaseDuration ?? DefaultLeaseDuration);
 
             if (onReceive != null)
             {

--- a/Alluvial.Tests/Infrastructure/Wait.cs
+++ b/Alluvial.Tests/Infrastructure/Wait.cs
@@ -65,11 +65,9 @@ namespace Alluvial.Tests
         }
 
         public static async Task Until(
-            Func<bool> until,
-            TimeSpan? pollInterval = null,
-            TimeSpan? timeout = null)
-        {
+                Func<bool> until,
+                TimeSpan? pollInterval = null,
+                TimeSpan? timeout = null) =>
             await Until(() => until().CompletedTask(), pollInterval, timeout);
-        }
     }
 }

--- a/Alluvial.Tests/Infrastructure/Wait.cs
+++ b/Alluvial.Tests/Infrastructure/Wait.cs
@@ -40,8 +40,8 @@ namespace Alluvial.Tests
         {
             timeout = timeout ??
                       (Debugger.IsAttached
-                           ? (TimeSpan.FromMinutes(5))
-                           : (TimeSpan.FromSeconds(20)));
+                           ? TimeSpan.FromMinutes(5)
+                           : TimeSpan.FromSeconds(10));
 
             pollInterval = pollInterval ?? TimeSpan.FromMilliseconds(100);
 

--- a/Alluvial.Tests/LeaseTests.cs
+++ b/Alluvial.Tests/LeaseTests.cs
@@ -50,7 +50,7 @@ namespace Alluvial.Tests
         }
 
         [Test]
-        public async Task Lease_expiration_is_triggered_by_canceling_the_cancelation_token()
+        public async Task Lease_expiration_is_triggered_by_releasing_the_lease()
         {
             var stopwatch = new Stopwatch();
             stopwatch.Start();
@@ -61,7 +61,7 @@ namespace Alluvial.Tests
 
             var task1 = Task.Run(async () => await lease.Expiration());
 
-            var task2 = Task.Run(() => lease.Cancel());
+            var task2 = Task.Run(() => lease.Release().Wait());
 
             await Task.WhenAll(task1, task2);
 

--- a/Alluvial.Tests/LeaseTests.cs
+++ b/Alluvial.Tests/LeaseTests.cs
@@ -84,6 +84,7 @@ namespace Alluvial.Tests
             lease.CancellationToken.IsCancellationRequested.Should().BeFalse();
         }
 
+        [Ignore] // FIX: (A_lease_can_be_extended_more_than_once_and_extensions_are_cumulative) this will be rewritten such that the last call supersedes the previous ones
         [Test]
         public async Task A_lease_can_be_extended_more_than_once_and_extensions_are_cumulative()
         {

--- a/Alluvial.Tests/LeaseTests.cs
+++ b/Alluvial.Tests/LeaseTests.cs
@@ -107,6 +107,19 @@ namespace Alluvial.Tests
         }
 
         [Test]
+        public async Task A_lease_cannot_be_created_with_a_negative_duration()
+        {
+            Action create = () =>
+                    new Lease(TimeSpan.FromSeconds(-1));
+
+            create.ShouldThrow<ArgumentException>()
+                  .And
+                  .Message
+                  .Should()
+                  .Be("Lease duration cannot be negative.");
+        }
+
+        [Test]
         public async Task Leases_cannot_be_extended_by_a_negative_timespan()
         {
             var lease = new Lease<string>(leasable,

--- a/Alluvial.Tests/LeaseTests.cs
+++ b/Alluvial.Tests/LeaseTests.cs
@@ -84,7 +84,6 @@ namespace Alluvial.Tests
             lease.CancellationToken.IsCancellationRequested.Should().BeFalse();
         }
 
-        [Ignore] // FIX: (A_lease_can_be_extended_more_than_once_and_extensions_are_cumulative) this will be rewritten such that the last call supersedes the previous ones
         [Test]
         public async Task A_lease_can_be_extended_more_than_once_and_extensions_are_cumulative()
         {

--- a/Alluvial.Tests/MultiStreamCatchupTests.cs
+++ b/Alluvial.Tests/MultiStreamCatchupTests.cs
@@ -34,7 +34,7 @@ namespace Alluvial.Tests
 
             foreach (var streamId in streamIds)
             {
-                store.WriteEvents(streamId, 1m);
+                store.WriteEvent(streamId);
             }
 
             streamSource = new NEventStoreStreamSource(store);
@@ -200,7 +200,7 @@ namespace Alluvial.Tests
 
                 var streamId = streamIds.First();
 
-                store.WriteEvents(streamId, 100m);
+                store.WriteEvent(streamId, amount: 100m);
 
                 await catchup.RunUntilCaughtUp();
 
@@ -228,7 +228,7 @@ namespace Alluvial.Tests
                 {
                     foreach (var streamId in Enumerable.Range(1, 20).Select(_ => Guid.NewGuid().ToString()))
                     {
-                        store.WriteEvents(streamId);
+                        store.WriteEvent(streamId);
                         await Task.Delay(1);
                     }
                     Console.WriteLine("wrote 200 more events");
@@ -263,7 +263,7 @@ namespace Alluvial.Tests
                         await Task.Delay(2);
                         if (!done)
                         {
-                            store.WriteEvents(streamId);
+                            store.WriteEvent(streamId);
                         }
                     }
                 });
@@ -397,17 +397,17 @@ namespace Alluvial.Tests
 
             using (catchup.Subscribe(new BalanceProjector()))
             {
-                store.WriteEvents(streamId);
+                store.WriteEvent(streamId);
                 await catchup.RunSingleBatch();
                 queriedEvents.Select(e => e.StreamRevision)
                              .ShouldBeEquivalentTo(new[] { 1 });
 
-                store.WriteEvents(streamId);
+                store.WriteEvent(streamId);
                 await catchup.RunSingleBatch();
                 queriedEvents.Select(e => e.StreamRevision)
                              .ShouldBeEquivalentTo(new[] { 1, 2 });
 
-                store.WriteEvents(streamId);
+                store.WriteEvent(streamId);
                 await catchup.RunSingleBatch();
                 queriedEvents.Select(e => e.StreamRevision)
                              .ShouldBeEquivalentTo(new[] { 1, 2, 3 });
@@ -439,9 +439,9 @@ namespace Alluvial.Tests
 
             using (catchup.Subscribe(new BalanceProjector(), balanceProjections))
             {
-                store.WriteEvents(streamId, amount: 1); // "101" - 1
-                store.WriteEvents(streamId, amount: 2); // "102" - 2
-                store.WriteEvents(streamId, amount: 3); // "103" - 3
+                store.WriteEvent(streamId, amount: 1); // "101" - 1
+                store.WriteEvent(streamId, amount: 2); // "102" - 2
+                store.WriteEvent(streamId, amount: 3); // "103" - 3
 
                 await catchup.RunSingleBatch();
 
@@ -461,7 +461,7 @@ namespace Alluvial.Tests
 
                 using (catchup.Subscribe(new AccountHistoryProjector(), accountHistoryProjections))
                 {
-                    store.WriteEvents(streamId, amount: 4);
+                    store.WriteEvent(streamId, amount: 4);
 
                     await catchup.RunSingleBatch();
 
@@ -496,9 +496,9 @@ namespace Alluvial.Tests
             var catchup = StreamCatchup.All(streamSource.StreamPerAggregate());
             using (catchup.Subscribe(new BalanceProjector(), projectionStore))
             {
-                store.WriteEvents(streamId);
-                store.WriteEvents(streamId);
-                store.WriteEvents(streamId);
+                store.WriteEvent(streamId);
+                store.WriteEvent(streamId);
+                store.WriteEvent(streamId);
 
                 await catchup.RunSingleBatch();
             }

--- a/Alluvial.Tests/MultiStreamCatchupTests.cs
+++ b/Alluvial.Tests/MultiStreamCatchupTests.cs
@@ -252,7 +252,7 @@ namespace Alluvial.Tests
                 {
                     Console.WriteLine($"there are {streamIds.Length} stream ids");
 
-                    foreach (var streamId in streamIds.Take(20))
+                    foreach (var streamId in streamIds)
                     {
                         await Task.Delay(2);
                         store.WriteEvents(streamId);

--- a/Alluvial.Tests/MultiStreamCatchupTests.cs
+++ b/Alluvial.Tests/MultiStreamCatchupTests.cs
@@ -550,7 +550,6 @@ namespace Alluvial.Tests
                                    .ToArray();
 
             var distributor = partitions.CreateInMemoryDistributor(
-                waitInterval: TimeSpan.FromSeconds(.5),
                 maxDegreesOfParallelism: 30,
                 defaultLeaseDuration: 5.Seconds())
                                         .Trace();

--- a/Alluvial.Tests/SingleStreamCatchupTests.cs
+++ b/Alluvial.Tests/SingleStreamCatchupTests.cs
@@ -29,7 +29,7 @@ namespace Alluvial.Tests
 
             streamId = Guid.NewGuid().ToString();
 
-            store.WriteEvents(streamId);
+            store.WriteEvent(streamId);
 
             stream = NEventStoreStream.ByAggregate(store, streamId).DomainEvents();
         }
@@ -281,17 +281,17 @@ namespace Alluvial.Tests
             }), batchSize: 1);
             catchup.Subscribe(new BalanceProjector());
 
-            store.WriteEvents(streamId);
+            store.WriteEvent(streamId);
             await catchup.RunSingleBatch();
             queriedEvents.Select(e => e.StreamRevision)
                          .ShouldBeEquivalentTo(new[] { 1 });
 
-            store.WriteEvents(streamId);
+            store.WriteEvent(streamId);
             await catchup.RunSingleBatch();
             queriedEvents.Select(e => e.StreamRevision)
                          .ShouldBeEquivalentTo(new[] { 1, 2 });
 
-            store.WriteEvents(streamId);
+            store.WriteEvent(streamId);
             await catchup.RunSingleBatch();
             queriedEvents.Select(e => e.StreamRevision)
                          .ShouldBeEquivalentTo(new[] { 1, 2, 3 });
@@ -334,7 +334,7 @@ namespace Alluvial.Tests
             });
             catchup.Subscribe(new AccountHistoryProjector(), accountHistoryProjections);
 
-            store.WriteEvents(streamId);
+            store.WriteEvent(streamId);
 
             await catchup.RunSingleBatch();
 
@@ -408,7 +408,7 @@ namespace Alluvial.Tests
 
             catchup.Subscribe(new BalanceProjector(), fetchAndSave);
 
-            store.WriteEvents(streamId, amount: 100m, howMany: 5);
+            store.WriteEvents(streamId, howMany: 5, amount: 100m);
 
             await catchup.RunSingleBatch();
 

--- a/Alluvial.Tests/SingleStreamCatchupTests.cs
+++ b/Alluvial.Tests/SingleStreamCatchupTests.cs
@@ -465,8 +465,6 @@ namespace Alluvial.Tests
 
             await Task.Delay(300);
 
-            Console.WriteLine(new { pollCount });
-
             pollCount.Should().Be(pollCountAtDispose);
         }
 
@@ -521,13 +519,12 @@ namespace Alluvial.Tests
                                    .ToArray();
 
             var distributor = partitions.CreateInMemoryDistributor(
-                waitInterval: TimeSpan.FromSeconds(.1),
                 maxDegreesOfParallelism: 30,
-                defaultLeaseDuration: 5.Seconds())
+                defaultLeaseDuration: 1.Seconds())
                                         .Trace();
 
             var catchup = stream.CreateDistributedCatchup(distributor)
-                                .Backoff(1.Seconds());
+                                .Backoff(3.Seconds());
 
             catchup.Subscribe(async (p, b) =>
             {

--- a/Alluvial.Tests/StreamCatchupErrorTests.cs
+++ b/Alluvial.Tests/StreamCatchupErrorTests.cs
@@ -28,7 +28,7 @@ namespace Alluvial.Tests
 
             foreach (var streamId in streamIds)
             {
-                store.WriteEvents(streamId);
+                store.WriteEvent(streamId);
             }
 
             streamSource = new NEventStoreStreamSource(store);

--- a/Alluvial.Tests/StreamImplementations/NEventStore/NEventStoreExtensions.cs
+++ b/Alluvial.Tests/StreamImplementations/NEventStore/NEventStoreExtensions.cs
@@ -41,11 +41,16 @@ namespace Alluvial.Tests.StreamImplementations.NEventStore
             }
         }
 
+        public static void WriteEvent(
+            this IStoreEvents store,
+            string streamId,
+            decimal amount = 1) => WriteEvents(store, streamId, 1, amount);
+
         public static void WriteEvents(
-            this IStoreEvents store, 
-            string streamId, 
+            this IStoreEvents store,
+            string streamId,
+            int howMany,
             decimal amount = 1, 
-            int howMany = 1, 
             string bucketId = "default")
         {
             for (var i = 0; i < howMany; i++)

--- a/Alluvial.Tests/StreamMapTests.cs
+++ b/Alluvial.Tests/StreamMapTests.cs
@@ -68,7 +68,8 @@ namespace Alluvial.Tests
             // catch up
             var distributor = Enumerable.Range(1, 10)
                                         .Select(i => Partition.ByValue(i.ToString()))
-                                        .CreateInMemoryDistributor();
+                                        .CreateInMemoryDistributor()
+                                        .AutoReleaseLeases();
 
             var catchup = domainEvents.CreateDistributedCatchup(
                 distributor,

--- a/Alluvial.Tests/StreamMapTests.cs
+++ b/Alluvial.Tests/StreamMapTests.cs
@@ -68,7 +68,7 @@ namespace Alluvial.Tests
             // catch up
             var distributor = Enumerable.Range(1, 10)
                                         .Select(i => Partition.ByValue(i.ToString()))
-                                        .CreateInMemoryDistributor(waitInterval: TimeSpan.FromSeconds(.5));
+                                        .CreateInMemoryDistributor();
 
             var catchup = domainEvents.CreateDistributedCatchup(
                 distributor,

--- a/Alluvial.Tests/StreamMapTests.cs
+++ b/Alluvial.Tests/StreamMapTests.cs
@@ -69,7 +69,7 @@ namespace Alluvial.Tests
             var distributor = Enumerable.Range(1, 10)
                                         .Select(i => Partition.ByValue(i.ToString()))
                                         .CreateInMemoryDistributor()
-                                        .AutoReleaseLeases();
+                                        .ReleaseLeasesWhenWorkIsDone();
 
             var catchup = domainEvents.CreateDistributedCatchup(
                 distributor,

--- a/Alluvial.Tests/StreamQueryDistributionTests.cs
+++ b/Alluvial.Tests/StreamQueryDistributionTests.cs
@@ -68,12 +68,12 @@ namespace Alluvial.Tests
 
             var catchup = partitionedStream.Trace()
                                            .CreateDistributedCatchup(
-                                               partitions.CreateInMemoryDistributor(),
+                                               partitions.CreateInMemoryDistributor().AutoReleaseLeases(),
                                                batchSize: 15);
 
             catchup.Subscribe(aggregator, store.Trace());
 
-            await catchup.RunUntilCaughtUp();
+            await catchup.RunUntilCaughtUp().Timeout();
 
             partitions.ToList()
                       .ForEach(partition =>
@@ -103,13 +103,13 @@ namespace Alluvial.Tests
 
             var catchup = partitionedStream
                 .CreateDistributedCatchup(
-                    partitions.CreateInMemoryDistributor(),
+                    partitions.CreateInMemoryDistributor().AutoReleaseLeases(),
                     batchSize: 73,
                     fetchAndSavePartitionCursor: cursorStore.Trace().AsHandler());
 
             catchup.Subscribe(aggregator);
 
-            await catchup.RunUntilCaughtUp();
+            await catchup.RunUntilCaughtUp().Timeout();
 
             cursorStore.Count().Should().Be(26);
             Enumerable.Range(1, 26).ToList().ForEach(i => { cursorStore.Should().Contain(c => c.Position == i*100); });
@@ -149,7 +149,7 @@ namespace Alluvial.Tests
 
             catchup.Subscribe(aggregator);
 
-            await catchup.RunSingleBatch();
+            await catchup.RunSingleBatch().Timeout();
 
             cursorStore.Count().Should().Be(3);
         }

--- a/Alluvial.Tests/StreamQueryDistributionTests.cs
+++ b/Alluvial.Tests/StreamQueryDistributionTests.cs
@@ -68,7 +68,7 @@ namespace Alluvial.Tests
 
             var catchup = partitionedStream.Trace()
                                            .CreateDistributedCatchup(
-                                               partitions.CreateInMemoryDistributor(waitInterval: TimeSpan.FromSeconds(.1)),
+                                               partitions.CreateInMemoryDistributor(),
                                                batchSize: 15);
 
             catchup.Subscribe(aggregator, store.Trace());
@@ -103,7 +103,7 @@ namespace Alluvial.Tests
 
             var catchup = partitionedStream
                 .CreateDistributedCatchup(
-                    partitions.CreateInMemoryDistributor(waitInterval: TimeSpan.FromSeconds(.1)),
+                    partitions.CreateInMemoryDistributor(),
                     batchSize: 73,
                     fetchAndSavePartitionCursor: cursorStore.Trace().AsHandler());
 

--- a/Alluvial.Tests/StreamQueryDistributionTests.cs
+++ b/Alluvial.Tests/StreamQueryDistributionTests.cs
@@ -68,7 +68,7 @@ namespace Alluvial.Tests
 
             var catchup = partitionedStream.Trace()
                                            .CreateDistributedCatchup(
-                                               partitions.CreateInMemoryDistributor().AutoReleaseLeases(),
+                                               partitions.CreateInMemoryDistributor().ReleaseLeasesWhenWorkIsDone(),
                                                batchSize: 15);
 
             catchup.Subscribe(aggregator, store.Trace());
@@ -103,7 +103,7 @@ namespace Alluvial.Tests
 
             var catchup = partitionedStream
                 .CreateDistributedCatchup(
-                    partitions.CreateInMemoryDistributor().AutoReleaseLeases(),
+                    partitions.CreateInMemoryDistributor().ReleaseLeasesWhenWorkIsDone(),
                     batchSize: 73,
                     fetchAndSavePartitionCursor: cursorStore.Trace().AsHandler());
 

--- a/Alluvial.Tests/TracingTests.cs
+++ b/Alluvial.Tests/TracingTests.cs
@@ -262,11 +262,12 @@ namespace Alluvial.Tests
         {
             Exception caughtException = null;
             var distributor = new TestDistributor<int>(
-                Enumerable.Range(1, 10)
-                          .Select(i => new Leasable<int>(i, i.ToString()))
-                          .ToArray(),
-                beforeRelease: async lease => { throw new Exception("dang!"); })
-                .Trace(onException: (ex, lease) => caughtException = ex);
+                    Enumerable.Range(1, 10)
+                              .Select(i => new Leasable<int>(i, i.ToString()))
+                              .ToArray(),
+                    beforeRelease: async lease => { throw new Exception("dang!"); })
+                .Trace(onException: (ex, lease) => caughtException = ex)
+                .AutoReleaseLeases();
 
             await distributor.Distribute(1);
 
@@ -277,7 +278,7 @@ namespace Alluvial.Tests
         public async Task Distributor_Trace_writes_pool_name_on_all_trace_events()
         {
             var poolName = "this-is-the-pool";
-            var distributor = CreateDistributor(pool: poolName).Trace();
+            var distributor = CreateDistributor(pool: poolName).Trace().AutoReleaseLeases();
 
             await distributor.Distribute(1);
 

--- a/Alluvial.Tests/TracingTests.cs
+++ b/Alluvial.Tests/TracingTests.cs
@@ -267,7 +267,7 @@ namespace Alluvial.Tests
                               .ToArray(),
                     beforeRelease: async lease => { throw new Exception("dang!"); })
                 .Trace(onException: (ex, lease) => caughtException = ex)
-                .AutoReleaseLeases();
+                .ReleaseLeasesWhenWorkIsDone();
 
             await distributor.Distribute(1);
 
@@ -278,7 +278,7 @@ namespace Alluvial.Tests
         public async Task Distributor_Trace_writes_pool_name_on_all_trace_events()
         {
             var poolName = "this-is-the-pool";
-            var distributor = CreateDistributor(pool: poolName).Trace().AutoReleaseLeases();
+            var distributor = CreateDistributor(pool: poolName).Trace().ReleaseLeasesWhenWorkIsDone();
 
             await distributor.Distribute(1);
 

--- a/Alluvial.Tests/TracingTests.cs
+++ b/Alluvial.Tests/TracingTests.cs
@@ -144,7 +144,7 @@ namespace Alluvial.Tests
 
             traceListener.Messages
                          .Should()
-                         .ContainSingle(m => m == "[Store.Put] Projection<IDomainEvent,Int32>: null @ cursor 0 for stream the-stream-id");
+                         .ContainSingle(m => m == "[Store.Put] Projection<String,Int32>: null @ cursor 0 for stream the-stream-id");
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace Alluvial.Tests
 
             traceListener.Messages
                          .Should()
-                         .ContainSingle(m => m == "[Store.Get] Projection<IDomainEvent,Int32>: null @ cursor 0 for stream the-stream-id");
+                         .ContainSingle(m => m == "[Store.Get] Projection<String,Int32>: null @ cursor 0 for stream the-stream-id");
         }
 
         [Test]

--- a/Alluvial/Alluvial.nuspec
+++ b/Alluvial/Alluvial.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Alluvial</id>
     <title>Alluvial</title>
-    <version>0.2.5</version>
+    <version>0.3.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/Alluvial</projectUrl>

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -11,6 +11,11 @@ namespace Alluvial
     /// </summary>
     public static class Distributor
     {
+        /// <summary>
+        /// Configures the distributor to release leases as soon as the work on the lease is completed.
+        /// </summary>
+        /// <typeparam name="T">The type of the distributed resource.</typeparam>
+        /// <param name="distributor">The distributor.</param>
         public static IDistributor<T> AutoReleaseLeases<T>(
             this IDistributor<T> distributor)
         {

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -11,6 +11,18 @@ namespace Alluvial
     /// </summary>
     public static class Distributor
     {
+        public static IDistributor<T> AutoReleaseLeases<T>(
+            this IDistributor<T> distributor)
+        {
+            distributor.OnReceive(async (lease, next) =>
+            {
+                await next(lease);
+                await lease.Release();
+            });
+
+            return distributor;
+        }
+
         /// <summary>
         /// Creates an anonymous distributor.
         /// </summary>

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -153,8 +153,14 @@ namespace Alluvial
         /// <summary>
         /// Specifies a delegate to be called when a lease is available.
         /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="distributor">The distributor.</param>
         /// <param name="receive">The delegate called when work is available to be done.</param>
-        /// <remarks>For the duration of the lease, the leased resource will not be available to any other instance.</remarks>
+        /// <exception cref="System.ArgumentNullException">
+        /// </exception>
+        /// <remarks>
+        /// For the duration of the lease, the leased resource will not be available to any other instance.
+        /// </remarks>
         public static void OnReceive<T>(
             this IDistributor<T> distributor,
             Func<Lease<T>, Task> receive)

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -16,7 +16,7 @@ namespace Alluvial
         /// </summary>
         /// <typeparam name="T">The type of the distributed resource.</typeparam>
         /// <param name="distributor">The distributor.</param>
-        public static IDistributor<T> AutoReleaseLeases<T>(
+        public static IDistributor<T> ReleaseLeasesWhenWorkIsDone<T>(
             this IDistributor<T> distributor)
         {
             distributor.OnReceive(async (lease, next) =>

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -36,7 +36,6 @@ namespace Alluvial
         /// <param name="partitions">The partitions to be leased out.</param>
         /// <param name="maxDegreesOfParallelism">The maximum degrees of parallelism.</param>
         /// <param name="pool">The pool.</param>
-        /// <param name="waitInterval">The wait interval. If not specified, the default is 5 seconds.</param>
         /// <param name="defaultLeaseDuration">Default duration of the lease. If not specified, the default is 1 minute.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException"></exception>
@@ -44,7 +43,6 @@ namespace Alluvial
             this IEnumerable<IStreamQueryPartition<TPartition>> partitions,
             int maxDegreesOfParallelism = 5,
             string pool = "default",
-            TimeSpan? waitInterval = null,
             TimeSpan? defaultLeaseDuration = null)
         {
             if (partitions == null)
@@ -58,7 +56,6 @@ namespace Alluvial
                 leasables,
                 pool,
                 maxDegreesOfParallelism,
-                waitInterval,
                 defaultLeaseDuration);
         }
 

--- a/Alluvial/DistributorBase{T}.cs
+++ b/Alluvial/DistributorBase{T}.cs
@@ -65,6 +65,7 @@ namespace Alluvial
             this.leasables = leasables;
             this.maxDegreesOfParallelism = Math.Min(maxDegreesOfParallelism, leasables.Length);
 
+            // ReSharper disable once PossibleLossOfFraction
             waitAfterFailureToAcquireLease = TimeSpan.FromMilliseconds(5000/maxDegreesOfParallelism);
             waitBeforeStop = TimeSpan.FromSeconds(1);
         }
@@ -294,7 +295,7 @@ namespace Alluvial
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        public void Dispose() => Task.Run(() => Stop()).Wait();
+        public void Dispose() => Task.Run(Stop).Wait();
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.

--- a/Alluvial/DistributorBase{T}.cs
+++ b/Alluvial/DistributorBase{T}.cs
@@ -21,7 +21,7 @@ namespace Alluvial
         private readonly TimeSpan waitAfterFailureToAcquireLease;
 
         private readonly Leasable<T>[] leasables;
-        private int leasesHeld;
+        private int countOfLeasesInUse;
         private DistributorPipeAsync<T> pipeline;
 
         private event Action<Exception, Lease<T>> CaughtException;
@@ -197,7 +197,7 @@ namespace Alluvial
                 Debug.WriteLine($"[Distribute] {ToString()}: Acquired lease {lease.ResourceName} @ {stopwatch.ElapsedMilliseconds}ms");
 #endif
 
-                Interlocked.Increment(ref leasesHeld);
+                Interlocked.Increment(ref countOfLeasesInUse);
 
                 try
                 {
@@ -227,7 +227,7 @@ namespace Alluvial
                     CaughtException?.Invoke(exception, lease);
                 }
 
-                Interlocked.Decrement(ref leasesHeld);
+                Interlocked.Decrement(ref countOfLeasesInUse);
             }
             else
             {
@@ -279,9 +279,9 @@ namespace Alluvial
         {
             stopped = true;
 
-            while (leasesHeld > 0)
+            while (countOfLeasesInUse > 0)
             {
-                Debug.WriteLine($"[Distribute] {ToString()}: Stop: waiting for {leasesHeld} leases to complete");
+                Debug.WriteLine($"[Distribute] {ToString()}: Stop: waiting for {countOfLeasesInUse} leases to complete");
                 await Task.Delay(waitBeforeStop);
             }
         }

--- a/Alluvial/DistributorBase{T}.cs
+++ b/Alluvial/DistributorBase{T}.cs
@@ -171,7 +171,6 @@ namespace Alluvial
         {
             if (stopped)
             {
-                Debug.WriteLine($"[Distribute] {ToString()}: Aborting");
                 return LeaseAcquisitionAttempt.Failed();
             }
 

--- a/Alluvial/DistributorBase{T}.cs
+++ b/Alluvial/DistributorBase{T}.cs
@@ -217,13 +217,16 @@ namespace Alluvial
                     lease.Exception = exception;
                 }
 
-                try
+                if (AutoReleaseLeases)
                 {
-                    await ReleaseLease(lease);
-                }
-                catch (Exception exception)
-                {
-                    CaughtException?.Invoke(exception, lease);
+                    try
+                    {
+                        await ReleaseLease(lease);
+                    }
+                    catch (Exception exception)
+                    {
+                        CaughtException?.Invoke(exception, lease);
+                    }
                 }
 
                 Interlocked.Decrement(ref countOfLeasesInUse);
@@ -259,6 +262,8 @@ namespace Alluvial
 
             return LeaseAcquisitionAttempt.Failed();
         }
+
+        internal bool AutoReleaseLeases { get; set; } = true;
 
         /// <summary>
         /// Releases the specified lease.

--- a/Alluvial/DistributorBase{T}.cs
+++ b/Alluvial/DistributorBase{T}.cs
@@ -131,6 +131,7 @@ namespace Alluvial
             while (acquired.Count < count &&
                    !stopped)
             {
+
                 var acquisition = await TryRunOne(loop: false);
                 if (acquisition.Acquired)
                 {

--- a/Alluvial/DistributorBase{T}.cs
+++ b/Alluvial/DistributorBase{T}.cs
@@ -219,18 +219,6 @@ namespace Alluvial
                     lease.Exception = exception;
                 }
 
-                if (AutoReleaseLeases)
-                {
-                    try
-                    {
-                        await ReleaseLease(lease);
-                    }
-                    catch (Exception exception)
-                    {
-                        CaughtException?.Invoke(exception, lease);
-                    }
-                }
-
                 Interlocked.Decrement(ref countOfLeasesInUse);
             }
             else
@@ -264,8 +252,6 @@ namespace Alluvial
 
             return LeaseAcquisitionAttempt.Failed();
         }
-
-        internal bool AutoReleaseLeases { get; set; } = true;
 
         /// <summary>
         /// Releases the specified lease.

--- a/Alluvial/ILease.cs
+++ b/Alluvial/ILease.cs
@@ -9,9 +9,9 @@ namespace Alluvial
     public interface ILease
     {
         /// <summary>
-        /// Cancels the lease.
+        /// Releases the lease.
         /// </summary>
-        void Cancel();
+        Task Release();
 
         /// <summary>
         /// Gets a task that completes when the lease is released or expired.

--- a/Alluvial/ILease.cs
+++ b/Alluvial/ILease.cs
@@ -9,11 +9,6 @@ namespace Alluvial
     public interface ILease
     {
         /// <summary>
-        /// Releases the lease.
-        /// </summary>
-        Task Release();
-
-        /// <summary>
         /// Gets a task that completes when the lease is released or expired.
         /// </summary>
         Task Expiration();
@@ -25,5 +20,10 @@ namespace Alluvial
         /// <returns></returns>
         /// <exception cref="System.InvalidOperationException">The lease cannot be extended.</exception>
         Task Extend(TimeSpan by);
+
+        /// <summary>
+        /// Releases the lease, making it available for acquisition by other workers.
+        /// </summary>
+        Task Release();
     }
 }

--- a/Alluvial/InMemoryDistributor.cs
+++ b/Alluvial/InMemoryDistributor.cs
@@ -56,7 +56,12 @@ namespace Alluvial
                 return null;
             }
 
-            var lease = new Lease<T>(resource, defaultLeaseDuration, OwnerToken.Next());
+            Lease<T> lease = null;
+            lease = new Lease<T>(
+                resource,
+                defaultLeaseDuration,
+                OwnerToken.Next(),
+                release: () => ReleaseLease(lease));
 
             if (workInProgress.TryAdd(resource, lease))
             {

--- a/Alluvial/Lease.cs
+++ b/Alluvial/Lease.cs
@@ -88,6 +88,9 @@ namespace Alluvial
         /// </summary>
         public Exception Exception { get; internal set; }
 
+        /// <summary>
+        /// Releases the lease, making it available for acquisition by other workers.
+        /// </summary>
         public async Task Release()
         {
             if (release != null)

--- a/Alluvial/Lease.cs
+++ b/Alluvial/Lease.cs
@@ -20,6 +20,7 @@ namespace Alluvial
         /// </summary>
         /// <param name="duration">The duration of the lease.</param>
         /// <param name="extend">A delegate that will be called if the lease is extended.</param>
+        /// <param name="release">A delegate that is called to release the lease.</param>
         public Lease(
             TimeSpan duration, 
             Func<TimeSpan, Task<TimeSpan>> extend = null,
@@ -101,9 +102,6 @@ namespace Alluvial
             cancellationTokenSource.Cancel();
         }
 
-        internal static ILease CreateDefault()
-        {
-            return new Lease(TimeSpan.FromMinutes(5));
-        }
+        internal static ILease CreateDefault() => new Lease(TimeSpan.FromMinutes(5));
     }
 }

--- a/Alluvial/Lease.cs
+++ b/Alluvial/Lease.cs
@@ -26,6 +26,11 @@ namespace Alluvial
             Func<TimeSpan, Task<TimeSpan>> extend = null,
             Func<Task> release = null)
         {
+            if (duration.Ticks < 0)
+            {
+                throw new ArgumentException("Lease duration cannot be negative.");
+            }
+
             this.duration = duration;
             this.extend = extend;
             this.release = release;

--- a/Alluvial/Lease{T}.cs
+++ b/Alluvial/Lease{T}.cs
@@ -18,13 +18,15 @@ namespace Alluvial
         /// <param name="leasable">The leasable resource.</param>
         /// <param name="duration">The duration of the lease.</param>
         /// <param name="ownerToken">The owner token.</param>
-        /// <param name="extend">The extend.</param>
+        /// <param name="extend">A delegate which can be called to extend the lease.</param>
         /// <exception cref="System.ArgumentNullException">leasable</exception>
         public Lease(
             Leasable<T> leasable,
             TimeSpan duration,
             int ownerToken,
-            Func<TimeSpan, Task<TimeSpan>> extend = null) : base(duration, extend)
+            Func<TimeSpan, Task<TimeSpan>> extend = null,
+            Func<Task> release = null) :
+            base(duration, extend, release)
         {
             if (leasable == null)
             {

--- a/Alluvial/Properties/AssemblyInfo.cs
+++ b/Alluvial/Properties/AssemblyInfo.cs
@@ -22,8 +22,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("ae1d48e9-ffcd-4e5e-b052-70e5446dfa23")]
 
-[assembly: AssemblyVersion("0.2.0")]
-[assembly: AssemblyInformationalVersion("0.2.5")]
+[assembly: AssemblyVersion("0.3.0")]
+[assembly: AssemblyInformationalVersion("0.3.0")]
 
 [assembly: InternalsVisibleTo("Alluvial.Tests")]
 

--- a/Alluvial/Properties/AssemblyInfo.cs
+++ b/Alluvial/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -15,12 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2016 Jon Sequeira")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: ComVisible(false)]
 [assembly: CLSCompliant(true)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("ae1d48e9-ffcd-4e5e-b052-70e5446dfa23")]
 
 [assembly: AssemblyVersion("0.3.0")]
 [assembly: AssemblyInformationalVersion("0.3.0")]

--- a/Alluvial/StreamCatchup.cs
+++ b/Alluvial/StreamCatchup.cs
@@ -269,7 +269,11 @@ namespace Alluvial
                 do
                 {
                     countBefore = counter.Value;
-                    await catchup.RunSingleBatch(lease ?? Lease.CreateDefault());
+
+                    await catchup.RunSingleBatch(
+                        lease ?? 
+                        Lease.CreateDefault());
+
                 } while (countBefore != counter.Value);
             }
         }

--- a/Alluvial/StreamCatchup.cs
+++ b/Alluvial/StreamCatchup.cs
@@ -34,7 +34,7 @@ namespace Alluvial
                     using (var counter = catchup.Count())
                     {
                         await catchup.RunSingleBatch(lease);
-
+                        
                         if (counter.Value == 0)
                         {
                             await lease.Extend(extendLeaseBy.Value);

--- a/Alluvial/StreamCatchupBase{T}.cs
+++ b/Alluvial/StreamCatchupBase{T}.cs
@@ -58,7 +58,7 @@ namespace Alluvial
             ICursor<TUpstreamCursor> initialCursor = null)
         {
             var tcs = new TaskCompletionSource<AggregationBatch<TUpstreamCursor>>();
-
+            
             if (synchronize)
             {
                 var exchange = Interlocked.CompareExchange<object>(ref batchTaskCompletionSource, tcs, null);

--- a/Alluvial/TaskExtensions.cs
+++ b/Alluvial/TaskExtensions.cs
@@ -14,26 +14,7 @@ namespace Alluvial
             return tasksArray.Select(t => t.Result);
         }
 
-        public static Task<T> CompletedTask<T>(this T result) => 
+        public static Task<T> CompletedTask<T>(this T result) =>
             Task.FromResult(result);
-
-        public static async Task TimeoutAfter(
-            this Task task,
-            Task timeout)
-        {
-            if (task.IsCompleted)
-            {
-                return;
-            }
-
-            if (task == await Task.WhenAny(task, timeout))
-            {
-                await task;
-            }
-            else
-            {
-                throw new TimeoutException();
-            }
-        }
     }
 }


### PR DESCRIPTION
Prior to this change, leases are always released once work is done. It's possible to extend the lease but since the aggregator, which is doing the work, has no access to the lease instance, it's hard to know how much to extend it by. 

This change makes leases expire by default only after their full term. They can be released early by calling `ILease.Release`.

This changes the use case for the `Distributor.Backoff` method somewhat. Previously, `Backoff` would extend the lease and await its expiration, meaning:

1.  that the lease would be removed from the pool for a specified period of time, and
2.  during that same period of time, the worker would not be polling for other leases. 

Now, 1 is the behavior by default. This means that `Backoff` really only affects the worker's behavior. Effectively, it means "slow down on the polling when there's no new incoming data on the stream."

The old behavior can still be achieved by calling the new `Distributor.AutoReleaseLeases` method.