### PR TITLE
Keepalive error handling

### DIFF
--- a/Alluvial.Tests/Alluvial.Tests.csproj
+++ b/Alluvial.Tests/Alluvial.Tests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Infrastructure\Event.cs" />
     <Compile Include="Infrastructure\Values.cs" />
     <Compile Include="Infrastructure\AsyncQueryable.cs" />
+    <Compile Include="LeaseExtensionsTests.cs" />
     <Compile Include="LeaseTests.cs" />
     <Compile Include="PartioningTests.cs" />
     <Compile Include="PipelineTests.cs" />

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -321,41 +321,6 @@ namespace Alluvial.Tests.Distributors
         }
 
         [Test]
-        public virtual async Task When_ExpireIn_is_called_after_a_lease_has_expired_then_it_throws()
-        {
-            Exception exception = null;
-            var distributor = CreateDistributor().Trace();
-            var mre = new AsyncManualResetEvent();
-
-            distributor.OnReceive(async lease =>
-            {
-                // wait too long, until another receiver gets the lease
-                await Task.Delay((int) (DefaultLeaseDuration.TotalMilliseconds*1.5));
-
-                // now try to extend the lease
-                try
-                {
-                    await lease.ExpireIn(TimeSpan.FromMilliseconds(1));
-                }
-                catch (Exception ex)
-                {
-                    exception = ex;
-                }
-
-                mre.Set();
-            });
-
-#pragma warning disable 4014
-            distributor.Distribute(1);
-#pragma warning restore 4014
-            await mre.WaitAsync().Timeout();
-            await Task.Delay(1000);
-
-            exception.Should().BeOfType<InvalidOperationException>();
-            exception.Message.Should().Contain("lease cannot be extended");
-        }
-
-        [Test]
         public async Task When_Start_is_called_before_OnReceive_it_throws()
         {
             var distributor = CreateDistributor();

--- a/Alluvial.Tests/Distributors/DistributorTests.cs
+++ b/Alluvial.Tests/Distributors/DistributorTests.cs
@@ -492,8 +492,56 @@ namespace Alluvial.Tests.Distributors
                 .ReleaseLeasesWhenWorkIsDone();
 
             await distributor.Distribute(1);
-            
+
             wasReleased.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task When_a_lease_has_been_released_and_ExpireIn_is_called_then_OnException_publishes_an_exception()
+        {
+            // arrange
+            var distributor = CreateDistributor(async lease =>
+            {
+                // trigger a lease expiration exception
+                await lease.Release();
+                await lease.ExpireIn(1.Milliseconds());
+            });
+
+            Exception handledException = null;
+
+            distributor.OnException((exception, lease) => { handledException = exception; });
+
+            // act
+            await distributor.Distribute(1);
+
+            await Task.Delay(10);
+
+            // assert
+            handledException.Should().NotBeNull();
+        }
+
+        [Test]
+        public async Task When_a_lease_has_expired_and_ExpireIn_is_called_then_OnException_publishes_an_exception()
+        {
+            // arrange
+            var distributor = CreateDistributor(async lease =>
+            {
+                // trigger a lease expiration exception
+                await lease.Expiration();
+                await lease.ExpireIn(1.Milliseconds());
+            });
+
+            Exception handledException = null;
+
+            distributor.OnException((exception, lease) => { handledException = exception; });
+
+            // act
+            await distributor.Distribute(1);
+
+            await Task.Delay(10);
+
+            // assert
+            handledException.Should().NotBeNull();
         }
     }
 }

--- a/Alluvial.Tests/LeaseExtensionsTests.cs
+++ b/Alluvial.Tests/LeaseExtensionsTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Alluvial.Tests
+{
+    [TestFixture]
+    public class LeaseExtensionsTests
+    {
+        [Test]
+        public async Task KeepAlive_retries_extending_the_expiration_when_there_is_a_transient_exception()
+        {
+            // arrange
+            var firstAttempt = true;
+
+            var lease = new Lease(
+                100.Milliseconds(),
+                expireIn: async _ =>
+                {
+                    if (firstAttempt)
+                    {
+                        firstAttempt = false;
+                        throw new TimeoutException("oops!");
+                    }
+                    return _;
+                });
+
+            // act
+            using (lease.KeepAlive(50.Milliseconds()))
+            {
+                await Task.Delay(200.Milliseconds());
+
+                // assert
+                lease.IsReleased.Should().BeFalse();
+            }
+        }
+
+        [Test]
+        public async Task KeepAlive_does_not_retry_when_lease_is_not_eligible_for_extension()
+        {
+            // arrange
+            var lease = new Lease(1.Seconds());
+
+            // act
+            using (lease.KeepAlive(10.Milliseconds()))
+            {
+                await lease.Release();
+                await Task.Delay(30.Milliseconds());
+
+                // assert
+                lease.Exception.Should().NotBeNull();
+                lease.Exception.Message.Should().Be("The lease cannot be extended.");
+            }
+        }
+    }
+}

--- a/Alluvial.Tests/LeaseTests.cs
+++ b/Alluvial.Tests/LeaseTests.cs
@@ -144,6 +144,26 @@ namespace Alluvial.Tests
         }
 
         [Test]
+        public async Task When_ExpireIn_is_called_after_the_lease_has_expired_then_the_Exception_property_is_populated_with_the_resulting_exception()
+        {
+            var lease = new Lease(1.Milliseconds());
+
+            await lease.Expiration();
+
+            try
+            {
+                lease.ExpireIn(1.Seconds()).Wait();
+            }
+            catch (Exception)
+            {
+            }
+
+            lease.Exception.Should().NotBeNull();
+            lease.Exception.Message.Should().Be("The lease cannot be extended.");
+
+        }
+
+        [Test]
         public async Task Lease_ExpireIn_does_not_accept_a_negative_timespan()
         {
             var lease = new Lease<string>(leasable,

--- a/Alluvial.Tests/LeaseTests.cs
+++ b/Alluvial.Tests/LeaseTests.cs
@@ -128,6 +128,22 @@ namespace Alluvial.Tests
         }
 
         [Test]
+        public async Task When_ExpireIn_is_called_after_the_lease_has_expired_then_it_throws()
+        {
+            var lease = new Lease(1.Milliseconds());
+
+            await lease.Expiration();
+
+            Action extend = () => lease.ExpireIn(1.Seconds()).Wait();
+
+            extend.ShouldThrow<InvalidOperationException>()
+                  .And
+                  .Message
+                  .Should()
+                  .Be("The lease cannot be extended.");
+        }
+
+        [Test]
         public async Task Lease_ExpireIn_does_not_accept_a_negative_timespan()
         {
             var lease = new Lease<string>(leasable,

--- a/Alluvial/Alluvial.csproj
+++ b/Alluvial/Alluvial.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Cursor{TPosition}.cs" />
     <Compile Include="DistributedMultiStreamCatchup{TData,TUpstreamCursor,TDownstreamCursor,TPartition}.cs" />
     <Compile Include="DistributorPipeAsync{T}.cs" />
+    <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="Fluent\CursorBuilder.cs" />
     <Compile Include="Fluent\CursorBuilder{T}.cs" />
     <Compile Include="Fluent\PartitionBuilder.cs" />
@@ -67,6 +68,7 @@
     <Compile Include="ILease.cs" />
     <Compile Include="Leasable{T}.cs" />
     <Compile Include="Lease.cs" />
+    <Compile Include="LeaseExpiredException.cs" />
     <Compile Include="LeaseExtensions.cs" />
     <Compile Include="Lease{T}.cs" />
     <Compile Include="Grouping.cs" />

--- a/Alluvial/Distributor.cs
+++ b/Alluvial/Distributor.cs
@@ -230,5 +230,11 @@ namespace Alluvial
 
         private static void TraceOnLeaseWorkDone<T>(IDistributor<T> distributor, Lease<T> lease) =>
             WriteLine($"[Distribute] {distributor}: OnReceive (done) " + lease);
+
+        internal static DistributorPipeAsync<T> PipeInto<T>(
+            this DistributorPipeAsync<T> first,
+            DistributorPipeAsync<T> next) => (lease, _ignored_) =>
+            first(lease,
+                l => next(l, _ => Unit.Default.CompletedTask()));
     }
 }

--- a/Alluvial/ExceptionExtensions.cs
+++ b/Alluvial/ExceptionExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace Alluvial
+{
+    internal static class ExceptionExtensions
+    {
+        private static readonly HashSet<Type> transientExceptionTypes = new HashSet<Type>
+        {
+            typeof(TimeoutException)
+        };
+
+        public static bool IsTransient(this Exception exception) =>
+            transientExceptionTypes.Contains(exception.GetType());
+
+        internal static void MarkAsPublished(this Exception exception) =>
+            exception.Data["__Alluvial__Published__"] = true;
+
+        public static bool HasBeenPublished(this Exception exception) =>
+            exception.Data.Contains("__Alluvial__Published__");
+    }
+}

--- a/Alluvial/Lease.cs
+++ b/Alluvial/Lease.cs
@@ -75,7 +75,8 @@ namespace Alluvial
             
             if (IsReleased)
             {
-                throw new InvalidOperationException("The lease cannot be extended.");
+                Exception = new LeaseExpiredException("The lease cannot be extended.");
+                throw Exception;
             }
 
             if (expireIn != null)

--- a/Alluvial/Lease.cs
+++ b/Alluvial/Lease.cs
@@ -73,7 +73,7 @@ namespace Alluvial
                 throw new ArgumentException("Lease cannot be extended by a negative timespan.");
             }
             
-            if (cancellationTokenSource.IsCancellationRequested)
+            if (IsReleased)
             {
                 throw new InvalidOperationException("The lease cannot be extended.");
             }

--- a/Alluvial/LeaseExpiredException.cs
+++ b/Alluvial/LeaseExpiredException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Alluvial
+{
+    /// <summary>
+    /// The exception thrown when an attempt is made to modify expired lease.
+    /// </summary>
+    /// <seealso cref="System.InvalidOperationException" />
+    public class LeaseExpiredException : InvalidOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseExpiredException"/> class.
+        /// </summary>
+        public LeaseExpiredException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseExpiredException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public LeaseExpiredException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/Alluvial/LeaseExtensions.cs
+++ b/Alluvial/LeaseExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Alluvial
@@ -25,8 +26,15 @@ namespace Alluvial
                 {
                     do
                     {
-                        await lease.ExpireIn(timeToExpiration);
-                        await Task.Delay(frequency);
+                        try
+                        {
+                            await lease.ExpireIn(timeToExpiration);
+                            await Task.Delay(frequency);
+                        }
+                        catch (Exception ex) when (ex.IsTransient())
+                        {
+                            Debug.WriteLine($"[KeepAlive] Caught transient exception: {ex}");
+                        }
                     } while (!disposed);
                 }, TaskCreationOptions.LongRunning);
 


### PR DESCRIPTION
This adds support for lease keepalives to retry transient exceptions, and for lease expiration exceptions to be observable via `Distributor.OnException`.